### PR TITLE
feat: redesign portfolio (Halpin-inspired) and refresh current role

### DIFF
--- a/option-a.html
+++ b/option-a.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Hello, I'm Rafat — Lead Software Engineer</title>
-  <meta name="description" content="A friendly little corner of the web for Rafat Ahmed — Lead Software Engineer building scalable, intuitive web things." />
+  <title>Hello, I'm Rafat — Senior Software Engineer</title>
+  <meta name="description" content="A friendly little corner of the web for Rafat Ahmed — Senior Software Engineer building scalable, intuitive web things." />
 
   <link rel="icon" href="../../../assets/images/favicon.ico" type="image/x-icon" />
 
@@ -172,22 +172,6 @@
       border: 1px solid #C8E6D0;
     }
     html.dark .chip { background: #1E433F; color: #C8E6D0; border-color: #2E5C57; }
-
-    /* Social pill (icon + label, used in contact + footer) */
-    .social-pill {
-      display: inline-flex; align-items: center; gap: 0.5rem;
-      padding: 0.55rem 0.9rem;
-      border-radius: 999px;
-      font-size: 13px; font-weight: 600;
-      background: #FDFBF6; color: #2C5F5D;
-      border: 1px solid #C8E6D0;
-      transition: transform 200ms ease, background-color 200ms ease, color 200ms ease, border-color 200ms ease;
-      min-height: 44px;
-    }
-    .social-pill:hover { background: #E5F2E9; border-color: #A8D5BA; transform: translateY(-1px); color: #2C5F5D; }
-    .social-pill:focus-visible { outline: 3px solid #F4A261; outline-offset: 2px; }
-    html.dark .social-pill { background: #163230; color: #E5F2E9; border-color: #2E5C57; }
-    html.dark .social-pill:hover { background: #1E433F; border-color: #4F9C70; }
 
     /* Section underline (wavy) — purely decorative */
     .label-wave { display: inline-block; }
@@ -367,7 +351,7 @@
         <p class="font-script text-3xl md:text-4xl text-mint-600 dark:text-mint-300">Hello, friend.</p>
         <h1 class="mt-1 font-script text-6xl md:text-7xl text-teal-700 dark:text-mint-200 leading-none">I'm Rafat.</h1>
         <p class="mt-5 text-lg md:text-xl text-teal-700/90 dark:text-mint-100/90 max-w-prose mx-auto">
-          Lead Software Engineer with a soft spot for microservices and AI-powered systems,
+          Senior Software Engineer with a soft spot for microservices,
           building scalable, functional, and friendly web things from
           <span class="font-script text-2xl text-coral-500">Dhaka, Bangladesh.</span>
         </p>
@@ -563,44 +547,19 @@
         </header>
 
         <ol class="relative border-l-2 border-dashed border-mint-300 dark:border-forest-600 ml-3 space-y-10">
-          <!-- Job 1 - Current -->
+          <!-- Job 1 -->
           <li class="pl-6 relative">
             <span class="absolute -left-[11px] top-1 w-5 h-5 rounded-full bg-coral-400 border-4 border-cream-100 dark:border-forest-900" aria-hidden="true"></span>
             <article class="card p-6">
               <div class="flex flex-wrap items-baseline justify-between gap-2">
-                <h3 class="text-xl font-extrabold text-teal-800 dark:text-mint-100">Lead Software Engineer</h3>
-                <span class="text-sm font-semibold text-coral-500">Jul 2025 – Present</span>
-              </div>
-              <p class="text-sm text-teal-700/80 dark:text-mint-200/80 mt-1">
-                <strong>TechJays</strong> · Remote
-              </p>
-              <ul class="mt-4 space-y-2 list-disc list-outside pl-5 text-[16px]">
-                <li>Lead the engineering team on an AI platform combining <strong>AI Manager</strong> — an AI-powered reporting system that automates analytics generation and insight delivery — with <strong>Meeting Intelligence</strong>, which captures and synthesizes meeting context into actionable summaries.</li>
-                <li>Contribute to <strong>HireFinch</strong>, the in-house AI candidate-evaluation platform that runs structured coding assessments and AI interviews so recruiters only meet validated talent.</li>
-                <li>Currently engaged with <strong>Fleetworthy</strong> (client) — the fleet-readiness platform unifying safety &amp; compliance, toll payments, and weigh-station bypass, trusted by ~80% of the largest North American fleets.</li>
-                <li>Lead architecture decisions across products, set engineering standards, and mentor the team on Python/Django + LLM-integrated systems.</li>
-              </ul>
-              <div class="mt-4 flex flex-wrap gap-2">
-                <span class="chip">Python</span><span class="chip">Django</span><span class="chip">PostgreSQL</span>
-                <span class="chip">Google Cloud</span><span class="chip">OpenAI</span><span class="chip">Elasticsearch</span>
-                <span class="chip">Kibana</span>
-              </div>
-            </article>
-          </li>
-
-          <!-- Job 2 - Green Pants Studio -->
-          <li class="pl-6 relative">
-            <span class="absolute -left-[11px] top-1 w-5 h-5 rounded-full bg-coral-300 border-4 border-cream-100 dark:border-forest-900" aria-hidden="true"></span>
-            <article class="card p-6">
-              <div class="flex flex-wrap items-baseline justify-between gap-2">
                 <h3 class="text-xl font-extrabold text-teal-800 dark:text-mint-100">Senior Software Engineer</h3>
-                <span class="text-sm font-semibold text-coral-500">Mar 2024 – Jul 2025</span>
+                <span class="text-sm font-semibold text-coral-500">May 2024 – Present</span>
               </div>
               <p class="text-sm text-teal-700/80 dark:text-mint-200/80 mt-1">
-                <strong>Green Pants Studio</strong> · Remote · Dhaka, Bangladesh
+                <strong>Vendidit Inc.</strong> · Remote
               </p>
               <ul class="mt-4 space-y-2 list-disc list-outside pl-5 text-[16px]">
-                <li>Built a robust multi-vendor system for <strong>Vendidit</strong> (client) covering seller onboarding, inventory, and customer management.</li>
+                <li>Designed a robust multi-vendor system for seller onboarding, inventory, and customer management.</li>
                 <li>Integrated SendGrid for real-time buyer-seller email notifications.</li>
                 <li>Achieved 53% unit test coverage using Jest and monitored performance via AWS CloudWatch.</li>
                 <li>Built real-time auction functionality with live video streaming for richer engagement.</li>
@@ -621,7 +580,7 @@
             <article class="card p-6">
               <div class="flex flex-wrap items-baseline justify-between gap-2">
                 <h3 class="text-xl font-extrabold text-teal-800 dark:text-mint-100">Senior Software Engineer</h3>
-                <span class="text-sm font-semibold text-coral-500">Dec 2021 – Feb 2024</span>
+                <span class="text-sm font-semibold text-coral-500">Dec 2021 – Apr 2024</span>
               </div>
               <p class="text-sm text-teal-700/80 dark:text-mint-200/80 mt-1">
                 <strong>Cefalo Bangladesh Ltd.</strong> · Hybrid
@@ -816,8 +775,8 @@
 
     <!-- ========== CONTACT ========== -->
     <section id="contact" class="section">
-      <div class="max-w-5xl mx-auto px-5 md:px-6">
-        <header class="max-w-prose mx-auto text-center mb-10">
+      <div class="max-w-prose mx-auto px-5 md:px-6">
+        <header class="text-center mb-10">
           <p class="font-script text-2xl text-mint-600 dark:text-mint-300">come say hi —</p>
           <h2 class="font-script text-5xl md:text-6xl text-teal-700 dark:text-mint-200 leading-none">Let's chat.</h2>
           <p class="mt-3 text-base text-teal-700/80 dark:text-mint-100/80">
@@ -828,59 +787,50 @@
 
         <div class="grid md:grid-cols-5 gap-6">
           <!-- Contact info -->
-          <aside class="md:col-span-2 card p-6 md:p-7 space-y-5" aria-label="Contact details">
-            <div>
-              <h3 class="font-script text-3xl text-teal-700 dark:text-mint-200 leading-none">Find me here.</h3>
-              <div class="mt-3 inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-mint-100 dark:bg-forest-700 border border-mint-200 dark:border-forest-600">
-                <span class="pulse-dot inline-block w-2 h-2 rounded-full bg-mint-500"></span>
-                <span class="text-xs font-semibold text-teal-700 dark:text-mint-200">Open to opportunities</span>
-              </div>
-            </div>
+          <aside class="md:col-span-2 card p-6 space-y-4" aria-label="Contact details">
+            <h3 class="font-script text-3xl text-teal-700 dark:text-mint-200 leading-none">Find me here.</h3>
 
-            <a href="mailto:rafatahmedorik@gmail.com" class="flex items-start gap-3 group -mx-2 px-2 py-1.5 rounded-xl hover:bg-mint-50 dark:hover:bg-forest-700/40 transition-colors">
+            <a href="mailto:rafatahmedorik@gmail.com" class="flex items-start gap-3 group">
               <span class="w-10 h-10 rounded-full bg-mint-100 dark:bg-forest-700 flex items-center justify-center text-teal-700 dark:text-mint-200 shrink-0">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h16v16H4z"/><polyline points="22,6 12,13 2,6"/></svg>
               </span>
-              <span class="min-w-0 flex-1">
+              <span>
                 <span class="block text-xs font-bold uppercase tracking-wide text-mint-600 dark:text-mint-300">Email</span>
-                <span class="block text-[15px] font-semibold group-hover:text-coral-500 transition-colors truncate">rafatahmedorik@gmail.com</span>
+                <span class="block text-[15px] font-semibold group-hover:text-coral-500 transition-colors break-all">rafatahmedorik@gmail.com</span>
               </span>
             </a>
 
-            <a href="tel:+8801911750945" class="flex items-start gap-3 group -mx-2 px-2 py-1.5 rounded-xl hover:bg-mint-50 dark:hover:bg-forest-700/40 transition-colors">
+            <a href="tel:+8801911750945" class="flex items-start gap-3 group">
               <span class="w-10 h-10 rounded-full bg-mint-100 dark:bg-forest-700 flex items-center justify-center text-teal-700 dark:text-mint-200 shrink-0">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.13.96.36 1.9.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.91.34 1.85.57 2.81.7A2 2 0 0 1 22 16.92Z"/></svg>
               </span>
-              <span class="min-w-0 flex-1">
+              <span>
                 <span class="block text-xs font-bold uppercase tracking-wide text-mint-600 dark:text-mint-300">Phone</span>
-                <span class="block text-[15px] font-semibold group-hover:text-coral-500 transition-colors whitespace-nowrap">+880 (1911) 750-945</span>
+                <span class="block text-[15px] font-semibold group-hover:text-coral-500 transition-colors">+880 (1911) 750-945</span>
               </span>
             </a>
 
-            <div class="flex items-start gap-3 px-2 py-1.5">
+            <div class="flex items-start gap-3">
               <span class="w-10 h-10 rounded-full bg-mint-100 dark:bg-forest-700 flex items-center justify-center text-teal-700 dark:text-mint-200 shrink-0">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0Z"/><circle cx="12" cy="10" r="3"/></svg>
               </span>
-              <span class="min-w-0 flex-1">
+              <span>
                 <span class="block text-xs font-bold uppercase tracking-wide text-mint-600 dark:text-mint-300">Where</span>
                 <span class="block text-[15px] font-semibold">Dhaka, Bangladesh</span>
               </span>
             </div>
 
-            <div class="pt-4 border-t border-mint-200 dark:border-forest-700">
-              <p class="text-xs font-bold uppercase tracking-wide text-mint-600 dark:text-mint-300 mb-3">Elsewhere</p>
-              <div class="flex gap-2.5">
-                <a href="https://github.com/rafat69ahmed" target="_blank" rel="noopener noreferrer" aria-label="GitHub (opens in new tab)" class="social-pill">
+            <div class="pt-3 border-t border-mint-200 dark:border-forest-700">
+              <p class="text-xs font-bold uppercase tracking-wide text-mint-600 dark:text-mint-300 mb-2">Elsewhere</p>
+              <div class="flex gap-2">
+                <a href="https://github.com/rafat69ahmed" target="_blank" rel="noopener noreferrer" aria-label="GitHub (opens in new tab)" class="w-11 h-11 rounded-full flex items-center justify-center bg-cream-100 dark:bg-forest-700 hover:bg-mint-200 dark:hover:bg-forest-600 text-teal-700 dark:text-mint-200 transition-colors">
                   <i class="fa-brands fa-github text-lg" aria-hidden="true"></i>
-                  <span>GitHub</span>
                 </a>
-                <a href="https://linkedin.com/in/rafat69ahmed/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn (opens in new tab)" class="social-pill">
+                <a href="https://linkedin.com/in/rafat69ahmed/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn (opens in new tab)" class="w-11 h-11 rounded-full flex items-center justify-center bg-cream-100 dark:bg-forest-700 hover:bg-mint-200 dark:hover:bg-forest-600 text-teal-700 dark:text-mint-200 transition-colors">
                   <i class="fa-brands fa-linkedin-in text-lg" aria-hidden="true"></i>
-                  <span>LinkedIn</span>
                 </a>
-                <a href="https://facebook.com/rafat.ahmed.146" target="_blank" rel="noopener noreferrer" aria-label="Facebook (opens in new tab)" class="social-pill">
+                <a href="https://facebook.com/rafat.ahmed.146" target="_blank" rel="noopener noreferrer" aria-label="Facebook (opens in new tab)" class="w-11 h-11 rounded-full flex items-center justify-center bg-cream-100 dark:bg-forest-700 hover:bg-mint-200 dark:hover:bg-forest-600 text-teal-700 dark:text-mint-200 transition-colors">
                   <i class="fa-brands fa-facebook-f text-lg" aria-hidden="true"></i>
-                  <span>Facebook</span>
                 </a>
               </div>
             </div>
@@ -946,60 +896,14 @@
 
   <!-- ========== FOOTER ========== -->
   <footer class="border-t border-mint-200 dark:border-forest-700 bg-cream-50 dark:bg-forest-800/60">
-    <div class="max-w-5xl mx-auto px-5 md:px-6 py-12">
-      <!-- Decorative little landscape -->
-      <div aria-hidden="true" class="flex justify-center mb-6">
-        <svg width="120" height="32" viewBox="0 0 120 32" fill="none" class="text-mint-400 dark:text-mint-600">
-          <circle cx="20" cy="10" r="5" fill="#F4A261" opacity="0.85"/>
-          <path d="M0 30 Q 20 18 40 24 T 80 22 T 120 26 L 120 32 L 0 32 Z" fill="currentColor" opacity="0.55"/>
-          <path d="M0 32 Q 30 26 60 30 T 120 28 L 120 32 L 0 32 Z" fill="currentColor"/>
-          <path d="M50 26 L 53 22 L 56 26 Z" fill="#2C5F5D"/>
-          <path d="M88 28 L 90 24 L 92 28 Z" fill="#2C5F5D"/>
-        </svg>
-      </div>
-
-      <p class="font-script text-3xl text-teal-700 dark:text-mint-200 leading-none text-center">— made with care —</p>
-
-      <!-- Quick nav links -->
-      <nav aria-label="Footer navigation" class="mt-6 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-sm font-semibold text-teal-700 dark:text-mint-200">
-        <a href="#home" class="hover:text-coral-500 transition-colors">Hello</a>
-        <span aria-hidden="true" class="text-mint-400">·</span>
-        <a href="#about" class="hover:text-coral-500 transition-colors">A short story</a>
-        <span aria-hidden="true" class="text-mint-400">·</span>
-        <a href="#work" class="hover:text-coral-500 transition-colors">What I do</a>
-        <span aria-hidden="true" class="text-mint-400">·</span>
-        <a href="#projects" class="hover:text-coral-500 transition-colors">Things I built</a>
-        <span aria-hidden="true" class="text-mint-400">·</span>
-        <a href="#skills" class="hover:text-coral-500 transition-colors">Tools I love</a>
-        <span aria-hidden="true" class="text-mint-400">·</span>
-        <a href="#contact" class="hover:text-coral-500 transition-colors">Let's chat</a>
-      </nav>
-
-      <!-- Social row -->
-      <div class="mt-6 flex flex-wrap items-center justify-center gap-2.5">
-        <a href="https://github.com/rafat69ahmed" target="_blank" rel="noopener noreferrer" aria-label="GitHub (opens in new tab)" class="social-pill">
-          <i class="fa-brands fa-github text-lg" aria-hidden="true"></i>
-          <span>GitHub</span>
-        </a>
-        <a href="https://linkedin.com/in/rafat69ahmed/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn (opens in new tab)" class="social-pill">
-          <i class="fa-brands fa-linkedin-in text-lg" aria-hidden="true"></i>
-          <span>LinkedIn</span>
-        </a>
-        <a href="mailto:rafatahmedorik@gmail.com" aria-label="Email Rafat" class="social-pill">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h16v16H4z"/><polyline points="22,6 12,13 2,6"/></svg>
-          <span>Email</span>
-        </a>
-      </div>
-
-      <!-- Fine print -->
-      <div class="mt-8 pt-6 border-t border-mint-200 dark:border-forest-700 flex flex-col sm:flex-row items-center justify-between gap-3 text-xs text-teal-700/70 dark:text-mint-100/70">
-        <p>&copy; <span id="year">2025</span> Rafat Ahmed · Built with cream, mint, and a lot of coffee.</p>
-        <p>
-          <a href="https://rafatahmed.xyz" class="font-semibold hover:text-coral-500 transition-colors">rafatahmed.xyz</a>
-          <span aria-hidden="true" class="mx-2">·</span>
-          <a href="#home" class="hover:text-coral-500 transition-colors">Back to top ↑</a>
-        </p>
-      </div>
+    <div class="max-w-prose mx-auto px-5 md:px-6 py-10 text-center">
+      <p class="font-script text-3xl text-teal-700 dark:text-mint-200 leading-none">— made with care —</p>
+      <p class="mt-3 text-sm text-teal-700/80 dark:text-mint-100/80">
+        &copy; <span id="year">2025</span> Rafat Ahmed. Built with cream, mint, and a lot of coffee.
+      </p>
+      <p class="mt-1 text-xs text-teal-700/60 dark:text-mint-100/60">
+        <a href="https://rafatahmed.com" class="hover:text-coral-500 transition-colors">rafatahmed.com</a>
+      </p>
     </div>
   </footer>
 

--- a/option-b.html
+++ b/option-b.html
@@ -1,0 +1,939 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Rafat Ahmed - Senior Software Engineer specializing in microservices architecture, scalable backend systems, and modern web platforms." />
+  <meta name="theme-color" content="#FAF8F3" />
+  <title>Rafat Ahmed - Senior Software Engineer</title>
+  <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico" />
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300;9..144,400;9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700&family=Caveat:wght@500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+
+  <!-- Tailwind -->
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- Font Awesome -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
+
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            ivory: {
+              DEFAULT: '#FAF8F3',
+              50: '#FCFAF6',
+              100: '#FAF8F3',
+              200: '#F2EEE6',
+              300: '#E8E2D4',
+            },
+            charcoal: {
+              DEFAULT: '#1F1B16',
+              50: '#3A352E',
+              100: '#1F1B16',
+              900: '#1A1814',
+            },
+            sage: {
+              DEFAULT: '#7BA098',
+              50: '#A6C0B9',
+              100: '#7BA098',
+              200: '#5E847B',
+              300: '#456760',
+            },
+            terracotta: {
+              DEFAULT: '#C97B5A',
+              50: '#D8967C',
+              100: '#C97B5A',
+              200: '#B0623F',
+            },
+          },
+          fontFamily: {
+            display: ['Fraunces', 'Georgia', 'serif'],
+            sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            script: ['Caveat', 'cursive'],
+            mono: ['"JetBrains Mono"', 'ui-monospace', 'SFMono-Regular', 'monospace'],
+          },
+          maxWidth: {
+            content: '1100px',
+          },
+          boxShadow: {
+            soft: '0 6px 20px -8px rgba(31, 27, 22, 0.12)',
+            lift: '0 14px 40px -16px rgba(31, 27, 22, 0.18)',
+          },
+        },
+      },
+    };
+  </script>
+
+  <style>
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background-color: #FAF8F3;
+      color: #1F1B16;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      line-height: 1.6;
+    }
+    .dark body, html.dark body {
+      background-color: #1A1814;
+      color: #FAF8F3;
+    }
+    .font-display { font-family: 'Fraunces', Georgia, serif; }
+    .font-script { font-family: 'Caveat', cursive; }
+    .font-mono   { font-family: 'JetBrains Mono', ui-monospace, monospace; }
+
+    /* Focus rings */
+    a:focus-visible, button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible {
+      outline: 2px solid #7BA098;
+      outline-offset: 3px;
+      border-radius: 6px;
+    }
+
+    /* Section number underline draw on entry */
+    .num-rule {
+      display: inline-block;
+      position: relative;
+    }
+    .num-rule::after {
+      content: '';
+      position: absolute;
+      left: 0; bottom: -6px;
+      height: 1px;
+      width: 0;
+      background-color: #7BA098;
+      transition: width 600ms ease-out;
+    }
+    .num-rule.in-view::after { width: 100%; }
+
+    /* Pulsing dot for status badge */
+    .pulse-dot {
+      position: relative;
+      display: inline-block;
+      width: 8px; height: 8px;
+      border-radius: 9999px;
+      background-color: #7BA098;
+    }
+    .pulse-dot::before {
+      content: '';
+      position: absolute; inset: 0;
+      border-radius: 9999px;
+      background-color: #7BA098;
+      animation: pulseRing 2s ease-out infinite;
+      opacity: 0.6;
+    }
+    @keyframes pulseRing {
+      0%   { transform: scale(1);   opacity: 0.6; }
+      80%  { transform: scale(2.4); opacity: 0; }
+      100% { transform: scale(2.4); opacity: 0; }
+    }
+
+    /* Fade-up on scroll */
+    .reveal {
+      opacity: 0;
+      transform: translateY(14px);
+      transition: opacity 300ms ease-out, transform 300ms ease-out;
+      will-change: opacity, transform;
+    }
+    .reveal.in-view { opacity: 1; transform: translateY(0); }
+
+    /* CTA hover lift */
+    .cta-lift { transition: transform 200ms ease-out, box-shadow 200ms ease-out, background-color 200ms ease-out, color 200ms ease-out, border-color 200ms ease-out; }
+    .cta-lift:hover { transform: translateY(-1px); }
+
+    /* Layered hero photo backdrop */
+    .layer-card {
+      position: absolute;
+      inset: 0;
+      border-radius: 1rem;
+      border: 1px solid #7BA098;
+      background-color: #F2EEE6;
+    }
+    .dark .layer-card { background-color: #232019; border-color: #5E847B; }
+
+    /* Project card hover */
+    .project-card { transition: transform 220ms ease-out, box-shadow 220ms ease-out; }
+    .project-card:hover { transform: translateY(-3px); }
+
+    /* Skill pill hover */
+    .skill-pill { transition: transform 200ms ease-out, background-color 200ms ease-out, color 200ms ease-out, border-color 200ms ease-out; }
+    .skill-pill:hover { transform: translateY(-2px); background-color: #7BA098; color: #FAF8F3; border-color: #7BA098; }
+
+    /* Custom scrollbar (subtle) */
+    ::-webkit-scrollbar { width: 10px; height: 10px; }
+    ::-webkit-scrollbar-track { background: #F2EEE6; }
+    ::-webkit-scrollbar-thumb { background: #7BA098; border-radius: 6px; }
+    .dark ::-webkit-scrollbar-track { background: #232019; }
+
+    /* Mobile menu transition */
+    .mobile-menu { transition: max-height 220ms ease-out, opacity 220ms ease-out; max-height: 0; overflow: hidden; opacity: 0; }
+    .mobile-menu.open { max-height: 480px; opacity: 1; }
+
+    /* Disable hover-induced motion for reduced motion */
+    @media (prefers-reduced-motion: reduce) {
+      .reveal, .cta-lift, .skill-pill, .project-card, .num-rule::after, .pulse-dot::before { transition: none !important; animation: none !important; }
+      .reveal { opacity: 1; transform: none; }
+      .num-rule::after { width: 100%; }
+      html { scroll-behavior: auto; }
+    }
+
+    /* Section accent rail (timeline) */
+    .timeline-rail { background: linear-gradient(to bottom, transparent, #7BA098 12%, #7BA098 88%, transparent); }
+
+    /* Form fields */
+    .field {
+      width: 100%;
+      padding: 12px 14px;
+      background-color: #FAF8F3;
+      border: 1px solid #E8E2D4;
+      border-radius: 12px;
+      color: #1F1B16;
+      font-size: 16px;
+      transition: border-color 180ms ease-out, box-shadow 180ms ease-out, background-color 180ms ease-out;
+    }
+    .field::placeholder { color: #8a8175; }
+    .field:focus { border-color: #7BA098; box-shadow: 0 0 0 3px rgba(123,160,152,0.18); outline: none; }
+    .field.invalid { border-color: #C97B5A; box-shadow: 0 0 0 3px rgba(201,123,90,0.18); }
+    .dark .field { background-color: #232019; border-color: #3a342c; color: #FAF8F3; }
+    .dark .field::placeholder { color: #968b7c; }
+  </style>
+</head>
+
+<body class="bg-ivory text-charcoal dark:bg-charcoal-900 dark:text-ivory selection:bg-sage/30">
+
+<!-- Skip link -->
+<a href="#main" class="sr-only focus:not-sr-only focus:absolute focus:top-3 focus:left-3 focus:z-[1000] focus:bg-charcoal focus:text-ivory focus:px-4 focus:py-2 focus:rounded-lg">Skip to main content</a>
+
+<!-- ===================== HEADER ===================== -->
+<header class="sticky top-0 z-40 backdrop-blur-md bg-ivory/80 dark:bg-charcoal-900/80 border-b border-ivory-300/60 dark:border-charcoal-50/40">
+  <nav class="max-w-content mx-auto px-5 sm:px-8 h-16 flex items-center justify-between" aria-label="Main">
+    <a href="#home" class="flex items-baseline gap-2 group" aria-label="Rafat Ahmed - home">
+      <span class="font-display text-xl font-medium tracking-tight">Rafat Ahmed</span>
+      <span class="font-mono text-[11px] text-sage-200 dark:text-sage hidden sm:inline">v9.0</span>
+    </a>
+
+    <!-- Desktop nav -->
+    <ul class="hidden md:flex items-center gap-7 font-mono text-[13px]">
+      <li><a class="hover:text-sage-200 dark:hover:text-sage transition-colors" href="#about"><span class="text-sage">01</span> / about</a></li>
+      <li><a class="hover:text-sage-200 dark:hover:text-sage transition-colors" href="#experience"><span class="text-sage">02</span> / work</a></li>
+      <li><a class="hover:text-sage-200 dark:hover:text-sage transition-colors" href="#projects"><span class="text-sage">03</span> / projects</a></li>
+      <li><a class="hover:text-sage-200 dark:hover:text-sage transition-colors" href="#skills"><span class="text-sage">04</span> / toolbox</a></li>
+      <li><a class="hover:text-sage-200 dark:hover:text-sage transition-colors" href="#contact"><span class="text-sage">05</span> / hello</a></li>
+    </ul>
+
+    <div class="flex items-center gap-2">
+      <button id="theme-toggle" class="cta-lift w-11 h-11 grid place-items-center rounded-full border border-ivory-300 dark:border-charcoal-50 hover:border-sage" aria-label="Toggle dark mode">
+        <i class="fa-regular fa-moon dark:hidden text-sm"></i>
+        <i class="fa-regular fa-sun hidden dark:inline text-sm"></i>
+      </button>
+      <button id="menu-toggle" class="md:hidden w-11 h-11 grid place-items-center rounded-full border border-ivory-300 dark:border-charcoal-50" aria-label="Open menu" aria-expanded="false" aria-controls="mobile-menu">
+        <i class="fa-solid fa-bars text-sm"></i>
+      </button>
+    </div>
+  </nav>
+
+  <!-- Mobile menu -->
+  <div id="mobile-menu" class="mobile-menu md:hidden border-t border-ivory-300 dark:border-charcoal-50">
+    <ul class="flex flex-col py-3 px-5 sm:px-8 font-mono text-sm">
+      <li><a class="block py-3" href="#about"><span class="text-sage">01</span> / about</a></li>
+      <li><a class="block py-3" href="#experience"><span class="text-sage">02</span> / work</a></li>
+      <li><a class="block py-3" href="#projects"><span class="text-sage">03</span> / projects</a></li>
+      <li><a class="block py-3" href="#skills"><span class="text-sage">04</span> / toolbox</a></li>
+      <li><a class="block py-3" href="#contact"><span class="text-sage">05</span> / hello</a></li>
+    </ul>
+  </div>
+</header>
+
+<main id="main">
+
+<!-- ===================== HERO ===================== -->
+<section id="home" class="relative pt-16 sm:pt-24 pb-24 sm:pb-32 overflow-hidden">
+  <div class="max-w-content mx-auto px-5 sm:px-8 grid lg:grid-cols-12 gap-12 lg:gap-16 items-center">
+
+    <!-- Left -->
+    <div class="lg:col-span-7 reveal">
+      <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-ivory-200 dark:bg-charcoal-50/40 border border-sage/40 mb-8">
+        <span class="pulse-dot" aria-hidden="true"></span>
+        <span class="font-mono text-[12px] tracking-wide text-charcoal dark:text-ivory">Available for new opportunities</span>
+      </div>
+
+      <p class="font-script text-3xl sm:text-4xl text-sage-200 dark:text-sage -mb-2 ml-1">hello, friend.</p>
+      <h1 class="font-display text-5xl sm:text-6xl lg:text-[5.25rem] leading-[1.02] tracking-tight font-medium">
+        Hi, I'm <span class="italic">Rafat</span>.
+      </h1>
+
+      <p class="mt-6 max-w-xl text-base sm:text-lg text-charcoal-50 dark:text-ivory-200/80 leading-relaxed">
+        Senior Software Engineer with expertise in microservices architecture, dedicated to building scalable, functional, and intuitive web applications.
+      </p>
+
+      <div class="mt-8 flex flex-wrap gap-3">
+        <a href="#projects" class="cta-lift inline-flex items-center gap-2 px-6 py-3 rounded-full bg-terracotta text-ivory hover:shadow-lift hover:bg-terracotta-200 font-medium text-sm">
+          See my work
+          <i class="fa-solid fa-arrow-right text-xs"></i>
+        </a>
+        <a href="#contact" class="cta-lift inline-flex items-center gap-2 px-6 py-3 rounded-full border border-charcoal/20 dark:border-ivory/20 hover:border-sage hover:text-sage-200 dark:hover:text-sage font-medium text-sm">
+          Say hello
+        </a>
+        <a href="assets/documents/rafat_ahmed_cv.pdf" download class="cta-lift inline-flex items-center gap-2 px-6 py-3 rounded-full font-medium text-sm hover:text-sage-200 dark:hover:text-sage">
+          <i class="fa-regular fa-file-lines"></i>
+          Download CV
+        </a>
+      </div>
+
+      <!-- Metrics strip -->
+      <dl class="mt-12 grid grid-cols-3 gap-6 max-w-lg">
+        <div>
+          <dt class="font-mono text-[11px] uppercase tracking-wider text-sage-200 dark:text-sage">Subscribers reached</dt>
+          <dd class="font-display text-2xl sm:text-3xl mt-1">5M+</dd>
+        </div>
+        <div>
+          <dt class="font-mono text-[11px] uppercase tracking-wider text-sage-200 dark:text-sage">Test coverage</dt>
+          <dd class="font-display text-2xl sm:text-3xl mt-1">82.4%</dd>
+        </div>
+        <div>
+          <dt class="font-mono text-[11px] uppercase tracking-wider text-sage-200 dark:text-sage">Years building</dt>
+          <dd class="font-display text-2xl sm:text-3xl mt-1">9+</dd>
+        </div>
+      </dl>
+    </div>
+
+    <!-- Right - Layered photo -->
+    <div class="lg:col-span-5 reveal">
+      <div class="relative w-full max-w-sm mx-auto aspect-square">
+        <!-- Stacked offset cards (Halpin echo) -->
+        <div class="layer-card -rotate-6 translate-x-6 translate-y-6 opacity-60"></div>
+        <div class="layer-card rotate-3 -translate-x-3 -translate-y-3 opacity-90"></div>
+        <!-- Photo frame -->
+        <div class="absolute inset-0 rounded-2xl border-2 border-sage bg-ivory-200 dark:bg-charcoal-50 p-2 shadow-soft">
+          <img src="assets/images/profile.jpg" alt="Portrait of Rafat Ahmed" width="600" height="600" class="w-full h-full object-cover rounded-xl" />
+        </div>
+        <!-- Floating badge -->
+        <div class="absolute -bottom-5 -left-5 sm:-left-8 bg-ivory dark:bg-charcoal-900 border border-sage/40 rounded-2xl px-4 py-3 shadow-soft">
+          <div class="flex items-center gap-3">
+            <div class="w-10 h-10 rounded-full bg-sage/15 grid place-items-center text-sage-200 dark:text-sage" aria-hidden="true">
+              <i class="fa-solid fa-code"></i>
+            </div>
+            <div>
+              <div class="font-mono text-[10px] uppercase tracking-wider text-sage-200 dark:text-sage">Currently</div>
+              <div class="text-sm font-medium">Backend architecture</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Subtle hero fade-out -->
+  <div class="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-b from-transparent to-ivory dark:to-charcoal-900"></div>
+</section>
+
+<!-- ===================== ABOUT ===================== -->
+<section id="about" class="bg-ivory-200 dark:bg-[#221E18] py-24 sm:py-32 border-y border-ivory-300/70 dark:border-charcoal-50/30">
+  <div class="max-w-content mx-auto px-5 sm:px-8 grid lg:grid-cols-12 gap-12">
+
+    <!-- Section label (left rail) -->
+    <div class="lg:col-span-3 reveal">
+      <div class="lg:sticky lg:top-24">
+        <span class="font-mono text-sage-200 dark:text-sage text-sm num-rule">01 / About</span>
+        <p class="font-script text-2xl text-sage-200 dark:text-sage mt-3">a short story.</p>
+      </div>
+    </div>
+
+    <!-- Body content -->
+    <div class="lg:col-span-9 reveal">
+      <h2 class="font-display text-4xl sm:text-5xl leading-tight font-medium tracking-tight">
+        Backend architect with a soft spot for <span class="italic">thoughtful frontends</span>.
+      </h2>
+
+      <div class="mt-8 grid md:grid-cols-2 gap-8 text-charcoal-50 dark:text-ivory-200/80 leading-relaxed">
+        <p>
+          Experienced software engineer and backend architect with over 9 years of industry expertise spanning diverse domains, platforms, and systems. For the past 7 years, I've been fully immersed in web development, bringing robust architectural thinking and scalable system design to every project.
+        </p>
+        <p>
+          I specialize in backend architecture and have efficient working knowledge of frontend architecture. My passion lies in designing reliable, maintainable infrastructure that aligns with modern best practices &mdash; TDD, Git Flow, containerization, and well-instrumented systems.
+        </p>
+      </div>
+
+      <!-- Principle cards (rhythm) -->
+      <div class="mt-10 grid sm:grid-cols-3 gap-4">
+        <div class="rounded-2xl border border-sage/30 bg-ivory dark:bg-charcoal-50/50 p-6">
+          <div class="font-mono text-[11px] uppercase tracking-wider text-sage-200 dark:text-sage">Principle 01</div>
+          <div class="font-display text-lg mt-2">Test-driven by default</div>
+          <p class="mt-2 text-sm text-charcoal-50 dark:text-ivory-200/70">Coverage is a feature. 82.4% Jest on production code.</p>
+        </div>
+        <div class="rounded-2xl border border-sage/30 bg-ivory dark:bg-charcoal-50/50 p-6">
+          <div class="font-mono text-[11px] uppercase tracking-wider text-sage-200 dark:text-sage">Principle 02</div>
+          <div class="font-display text-lg mt-2">Scale, then simplify</div>
+          <p class="mt-2 text-sm text-charcoal-50 dark:text-ivory-200/70">Microservices that earn their seams &mdash; not added by reflex.</p>
+        </div>
+        <div class="rounded-2xl border border-sage/30 bg-ivory dark:bg-charcoal-50/50 p-6">
+          <div class="font-mono text-[11px] uppercase tracking-wider text-sage-200 dark:text-sage">Principle 03</div>
+          <div class="font-display text-lg mt-2">Containerize everything</div>
+          <p class="mt-2 text-sm text-charcoal-50 dark:text-ivory-200/70">Docker, Git Flow, CI/CD &mdash; the boring infrastructure that lets work ship.</p>
+        </div>
+      </div>
+
+      <!-- Location row -->
+      <div class="mt-10 flex flex-wrap items-center gap-x-8 gap-y-3 font-mono text-[13px] text-charcoal-50 dark:text-ivory-200/80">
+        <span><i class="fa-solid fa-location-dot text-sage mr-2"></i>Dhaka, Bangladesh</span>
+        <span><i class="fa-regular fa-clock text-sage mr-2"></i>Remote-friendly</span>
+        <span><i class="fa-solid fa-cubes text-sage mr-2"></i>Backend &middot; Microservices &middot; Web</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== EXPERIENCE ===================== -->
+<section id="experience" class="py-24 sm:py-32">
+  <div class="max-w-content mx-auto px-5 sm:px-8">
+
+    <!-- Header row -->
+    <div class="grid lg:grid-cols-12 gap-12">
+      <div class="lg:col-span-3 reveal">
+        <span class="font-mono text-sage-200 dark:text-sage text-sm num-rule">02 / Work</span>
+        <p class="font-script text-2xl text-sage-200 dark:text-sage mt-3">things I've shipped.</p>
+      </div>
+      <div class="lg:col-span-9 reveal">
+        <h2 class="font-display text-4xl sm:text-5xl leading-tight font-medium tracking-tight">A timeline of teams, tools, and trade-offs.</h2>
+        <p class="mt-4 max-w-2xl text-charcoal-50 dark:text-ivory-200/80">From learning analytics for schools, to a 5M-subscriber news platform, to live-bidding auctions &mdash; here's the recent stretch.</p>
+      </div>
+    </div>
+
+    <!-- Timeline -->
+    <div class="relative mt-16">
+      <!-- Center rail (desktop) / left rail (mobile) -->
+      <div class="absolute top-0 bottom-0 w-px timeline-rail left-4 md:left-1/2 md:-translate-x-1/2" aria-hidden="true"></div>
+
+      <ol class="space-y-12 md:space-y-20">
+
+        <!-- Job 1 -->
+        <li class="relative reveal">
+          <div class="absolute left-4 md:left-1/2 md:-translate-x-1/2 top-7 w-3 h-3 rounded-full bg-sage ring-4 ring-ivory dark:ring-charcoal-900" aria-hidden="true"></div>
+          <div class="md:grid md:grid-cols-2 md:gap-12 items-start">
+            <!-- Date column -->
+            <div class="pl-12 md:pl-0 md:pr-12 md:text-right">
+              <div class="font-mono text-xs text-sage-200 dark:text-sage tracking-wide">May 2024 &mdash; Present</div>
+              <div class="font-display text-xl mt-1">Vendidit Inc.</div>
+              <div class="text-sm text-charcoal-50 dark:text-ivory-200/70">Remote &middot; Senior Software Engineer</div>
+            </div>
+            <!-- Card -->
+            <div class="pl-12 md:pl-0 mt-4 md:mt-0">
+              <article class="rounded-2xl border border-sage/30 bg-ivory-200 dark:bg-charcoal-50/40 p-6 sm:p-8 shadow-soft">
+                <h3 class="font-display text-lg">Live-auction platform &amp; multi-vendor system</h3>
+                <ul class="mt-4 space-y-2 text-sm text-charcoal-50 dark:text-ivory-200/85 list-disc pl-5 marker:text-sage">
+                  <li>Designed a robust multi-vendor system for seller onboarding, inventory, and customer management.</li>
+                  <li>Built real-time auction with live video streaming, supporting <strong>thousands of concurrent users</strong>.</li>
+                  <li>Achieved 53% Jest unit-test coverage; production monitored via AWS CloudWatch.</li>
+                  <li>Integrated SendGrid for buyer-seller real-time email notifications.</li>
+                </ul>
+                <div class="mt-5 flex flex-wrap gap-2 font-mono text-[11px]">
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">Node.js</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">NestJS</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">PostgreSQL</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">AWS</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">Lambda</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">React</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">Next.js</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">TypeScript</span>
+                </div>
+              </article>
+            </div>
+          </div>
+        </li>
+
+        <!-- Job 2 -->
+        <li class="relative reveal">
+          <div class="absolute left-4 md:left-1/2 md:-translate-x-1/2 top-7 w-3 h-3 rounded-full bg-sage ring-4 ring-ivory dark:ring-charcoal-900" aria-hidden="true"></div>
+          <div class="md:grid md:grid-cols-2 md:gap-12 items-start">
+            <!-- Card (left) -->
+            <div class="pl-12 md:pl-0 md:order-2 mt-4 md:mt-0">
+              <article class="rounded-2xl border border-sage/30 bg-ivory-200 dark:bg-charcoal-50/40 p-6 sm:p-8 shadow-soft">
+                <h3 class="font-display text-lg">Microservices, subscription system, and search</h3>
+                <ul class="mt-4 space-y-2 text-sm text-charcoal-50 dark:text-ivory-200/85 list-disc pl-5 marker:text-sage">
+                  <li>Microservice-based web apps for the leid.no rental service using Node.js &amp; Next.js.</li>
+                  <li>QR-code-based borrowing flow for tool rentals.</li>
+                  <li>Subscription system in PHP/Laravel/Node/Express used across multiple sites &mdash; <strong>5M subscribers</strong> on friflyt.no.</li>
+                  <li>Elasticsearch served via AWS Lambda; <strong>82.4% Jest coverage</strong>.</li>
+                </ul>
+                <div class="mt-5 flex flex-wrap gap-2 font-mono text-[11px]">
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">Node.js</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">Express</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">PHP</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">Laravel</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">AWS</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">Lambda</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">Elasticsearch</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">DatoCMS</span>
+                </div>
+              </article>
+            </div>
+            <!-- Date column -->
+            <div class="pl-12 md:pl-12 md:order-1 md:text-left mt-4 md:mt-0">
+              <div class="font-mono text-xs text-sage-200 dark:text-sage tracking-wide">Dec 2021 &mdash; Apr 2024</div>
+              <div class="font-display text-xl mt-1">Cefalo Bangladesh Ltd.</div>
+              <div class="text-sm text-charcoal-50 dark:text-ivory-200/70">Hybrid &middot; Senior Software Engineer</div>
+            </div>
+          </div>
+        </li>
+
+        <!-- Job 3 -->
+        <li class="relative reveal">
+          <div class="absolute left-4 md:left-1/2 md:-translate-x-1/2 top-7 w-3 h-3 rounded-full bg-sage ring-4 ring-ivory dark:ring-charcoal-900" aria-hidden="true"></div>
+          <div class="md:grid md:grid-cols-2 md:gap-12 items-start">
+            <div class="pl-12 md:pl-0 md:pr-12 md:text-right">
+              <div class="font-mono text-xs text-sage-200 dark:text-sage tracking-wide">May 2020 &mdash; Oct 2021</div>
+              <div class="font-display text-xl mt-1">Thrive EdTech</div>
+              <div class="text-sm text-charcoal-50 dark:text-ivory-200/70">Hybrid &middot; Senior Software Engineer</div>
+            </div>
+            <div class="pl-12 md:pl-0 mt-4 md:mt-0">
+              <article class="rounded-2xl border border-sage/30 bg-ivory-200 dark:bg-charcoal-50/40 p-6 sm:p-8 shadow-soft">
+                <h3 class="font-display text-lg">Learning analytics &amp; school management</h3>
+                <ul class="mt-4 space-y-2 text-sm text-charcoal-50 dark:text-ivory-200/85 list-disc pl-5 marker:text-sage">
+                  <li>Microservice apps tracking student/teacher results and progress over time.</li>
+                  <li>Routine planning + Zoom &amp; Google Meet integration for virtual classrooms.</li>
+                  <li>End-to-end product ownership across PHP/Laravel and React stacks.</li>
+                </ul>
+                <div class="mt-5 flex flex-wrap gap-2 font-mono text-[11px]">
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">PHP</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">Laravel</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">MySQL</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">React</span>
+                  <span class="px-2.5 py-1 rounded-md border border-sage/40 text-sage-200 dark:text-sage bg-ivory dark:bg-charcoal-900/40">AWS</span>
+                </div>
+              </article>
+            </div>
+          </div>
+        </li>
+      </ol>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== PROJECTS ===================== -->
+<section id="projects" class="bg-ivory-200 dark:bg-[#221E18] py-24 sm:py-32 border-y border-ivory-300/70 dark:border-charcoal-50/30">
+  <div class="max-w-content mx-auto px-5 sm:px-8">
+
+    <div class="grid lg:grid-cols-12 gap-12 mb-14">
+      <div class="lg:col-span-3 reveal">
+        <span class="font-mono text-sage-200 dark:text-sage text-sm num-rule">03 / Projects</span>
+        <p class="font-script text-2xl text-sage-200 dark:text-sage mt-3">selected work.</p>
+      </div>
+      <div class="lg:col-span-9 reveal">
+        <h2 class="font-display text-4xl sm:text-5xl leading-tight font-medium tracking-tight">Real systems with real users.</h2>
+        <p class="mt-4 max-w-2xl text-charcoal-50 dark:text-ivory-200/80">A peek at three platforms I helped architect and ship &mdash; from outdoor news to live auctions.</p>
+      </div>
+    </div>
+
+    <div class="grid lg:grid-cols-2 gap-8">
+
+      <!-- Project 1: friflyt -->
+      <article class="project-card rounded-2xl border border-sage/30 bg-ivory dark:bg-charcoal-50/40 overflow-hidden shadow-soft hover:shadow-lift reveal">
+        <div class="aspect-[16/10] overflow-hidden bg-ivory-200 dark:bg-charcoal-50">
+          <img src="assets/images/projects/friflyt.png" alt="Screenshot of friflyt.no e-news platform" loading="lazy" width="1280" height="800" class="w-full h-full object-cover" />
+        </div>
+        <div class="p-8 sm:p-10">
+          <div class="flex items-center justify-between gap-4 mb-3">
+            <span class="font-mono text-[11px] uppercase tracking-wider text-sage-200 dark:text-sage">E-news platform</span>
+            <a href="https://friflyt.no" target="_blank" rel="noopener" class="cta-lift inline-flex items-center gap-1.5 text-xs font-mono text-sage-200 dark:text-sage hover:text-terracotta">
+              friflyt.no <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i>
+            </a>
+          </div>
+          <h3 class="font-display text-2xl">Norwegian outdoor &amp; ski news</h3>
+          <p class="mt-3 text-sm text-charcoal-50 dark:text-ivory-200/80">News, reports and stories on skiing and outdoor adventure &mdash; centered on Norwegian nature and seasonal activities. Powers <strong>5M+ subscribers</strong>.</p>
+          <div class="mt-5 flex flex-wrap gap-2 font-mono text-[11px]">
+            <span class="px-2.5 py-1 rounded-md bg-ivory-200 dark:bg-charcoal-900/40 text-charcoal-50 dark:text-ivory-200">Express</span>
+            <span class="px-2.5 py-1 rounded-md bg-ivory-200 dark:bg-charcoal-900/40 text-charcoal-50 dark:text-ivory-200">MySQL</span>
+            <span class="px-2.5 py-1 rounded-md bg-ivory-200 dark:bg-charcoal-900/40 text-charcoal-50 dark:text-ivory-200">AWS</span>
+            <span class="px-2.5 py-1 rounded-md bg-ivory-200 dark:bg-charcoal-900/40 text-charcoal-50 dark:text-ivory-200">Lambda</span>
+          </div>
+        </div>
+      </article>
+
+      <!-- Project 2: leid -->
+      <article class="project-card rounded-2xl border border-sage/30 bg-ivory dark:bg-charcoal-50/40 overflow-hidden shadow-soft hover:shadow-lift reveal lg:translate-y-12">
+        <div class="aspect-[16/10] overflow-hidden bg-ivory-200 dark:bg-charcoal-50">
+          <img src="assets/images/projects/leid.png" alt="Screenshot of leid.no e-commerce rental platform" loading="lazy" width="1280" height="800" class="w-full h-full object-cover" />
+        </div>
+        <div class="p-8 sm:p-10">
+          <div class="flex items-center justify-between gap-4 mb-3">
+            <span class="font-mono text-[11px] uppercase tracking-wider text-sage-200 dark:text-sage">E-commerce / rental</span>
+            <a href="https://leid.no" target="_blank" rel="noopener" class="cta-lift inline-flex items-center gap-1.5 text-xs font-mono text-sage-200 dark:text-sage hover:text-terracotta">
+              leid.no <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i>
+            </a>
+          </div>
+          <h3 class="font-display text-2xl">Borrow tools, not buy them</h3>
+          <p class="mt-3 text-sm text-charcoal-50 dark:text-ivory-200/80">An e-commerce platform for renting tools, with a QR-code system that makes pickup and returns frictionless.</p>
+          <div class="mt-5 flex flex-wrap gap-2 font-mono text-[11px]">
+            <span class="px-2.5 py-1 rounded-md bg-ivory-200 dark:bg-charcoal-900/40 text-charcoal-50 dark:text-ivory-200">Express</span>
+            <span class="px-2.5 py-1 rounded-md bg-ivory-200 dark:bg-charcoal-900/40 text-charcoal-50 dark:text-ivory-200">PostgreSQL</span>
+            <span class="px-2.5 py-1 rounded-md bg-ivory-200 dark:bg-charcoal-900/40 text-charcoal-50 dark:text-ivory-200">AWS</span>
+            <span class="px-2.5 py-1 rounded-md bg-ivory-200 dark:bg-charcoal-900/40 text-charcoal-50 dark:text-ivory-200">Lambda</span>
+          </div>
+        </div>
+      </article>
+
+      <!-- Project 3: vendidit -->
+      <article class="project-card rounded-2xl border border-sage/30 bg-ivory dark:bg-charcoal-50/40 overflow-hidden shadow-soft hover:shadow-lift reveal lg:col-span-2">
+        <div class="grid lg:grid-cols-5">
+          <div class="lg:col-span-3 aspect-[16/10] lg:aspect-auto overflow-hidden bg-ivory-200 dark:bg-charcoal-50">
+            <img src="assets/images/projects/vendidit.png" alt="Screenshot of vendidit.com online auction platform" loading="lazy" width="1280" height="800" class="w-full h-full object-cover" />
+          </div>
+          <div class="lg:col-span-2 p-8 sm:p-10 flex flex-col justify-center">
+            <div class="flex items-center justify-between gap-4 mb-3">
+              <span class="font-mono text-[11px] uppercase tracking-wider text-sage-200 dark:text-sage">Online auctions</span>
+              <a href="https://vendidit.com" target="_blank" rel="noopener" class="cta-lift inline-flex items-center gap-1.5 text-xs font-mono text-sage-200 dark:text-sage hover:text-terracotta">
+                vendidit.com <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i>
+              </a>
+            </div>
+            <h3 class="font-display text-2xl">Real-time bidding, smooth UX</h3>
+            <p class="mt-3 text-sm text-charcoal-50 dark:text-ivory-200/80">A live auction platform with real-time bidding and integrated video streaming &mdash; built to support thousands of concurrent users without flinching.</p>
+            <div class="mt-5 flex flex-wrap gap-2 font-mono text-[11px]">
+              <span class="px-2.5 py-1 rounded-md bg-ivory-200 dark:bg-charcoal-900/40 text-charcoal-50 dark:text-ivory-200">NestJS</span>
+              <span class="px-2.5 py-1 rounded-md bg-ivory-200 dark:bg-charcoal-900/40 text-charcoal-50 dark:text-ivory-200">PostgreSQL</span>
+              <span class="px-2.5 py-1 rounded-md bg-ivory-200 dark:bg-charcoal-900/40 text-charcoal-50 dark:text-ivory-200">AWS</span>
+              <span class="px-2.5 py-1 rounded-md bg-ivory-200 dark:bg-charcoal-900/40 text-charcoal-50 dark:text-ivory-200">Lambda</span>
+            </div>
+          </div>
+        </div>
+      </article>
+
+    </div>
+  </div>
+</section>
+
+<!-- ===================== SKILLS ===================== -->
+<section id="skills" class="py-24 sm:py-32">
+  <div class="max-w-content mx-auto px-5 sm:px-8">
+
+    <div class="grid lg:grid-cols-12 gap-12 mb-12">
+      <div class="lg:col-span-3 reveal">
+        <span class="font-mono text-sage-200 dark:text-sage text-sm num-rule">04 / Toolbox</span>
+        <p class="font-script text-2xl text-sage-200 dark:text-sage mt-3">my toolbox.</p>
+      </div>
+      <div class="lg:col-span-9 reveal">
+        <h2 class="font-display text-4xl sm:text-5xl leading-tight font-medium tracking-tight">The stack I reach for.</h2>
+        <p class="mt-4 max-w-2xl text-charcoal-50 dark:text-ivory-200/80">Backend-leaning, but comfortable across the boundary &mdash; tested, containerized, and deployed.</p>
+      </div>
+    </div>
+
+    <!-- Skill pill grid -->
+    <div class="reveal flex flex-wrap gap-3 sm:gap-4">
+      <!-- Each pill: icon + label -->
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-solid fa-feather text-sage-200 group-hover:text-ivory" aria-hidden="true"></i> NestJS
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-brands fa-node-js text-sage-200" aria-hidden="true"></i> Node.js
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-brands fa-laravel text-sage-200" aria-hidden="true"></i> Laravel
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-brands fa-php text-sage-200" aria-hidden="true"></i> PHP
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-solid fa-database text-sage-200" aria-hidden="true"></i> PostgreSQL
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-solid fa-arrows-spin text-sage-200" aria-hidden="true"></i> CI/CD
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-brands fa-git-alt text-sage-200" aria-hidden="true"></i> Git
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-brands fa-docker text-sage-200" aria-hidden="true"></i> Docker
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-solid fa-leaf text-sage-200" aria-hidden="true"></i> MongoDB
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-brands fa-html5 text-sage-200" aria-hidden="true"></i> HTML5
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-brands fa-css3-alt text-sage-200" aria-hidden="true"></i> CSS3
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-brands fa-square-js text-sage-200" aria-hidden="true"></i> JavaScript
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-brands fa-react text-sage-200" aria-hidden="true"></i> React
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-brands fa-java text-sage-200" aria-hidden="true"></i> Java
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-solid fa-database text-sage-200" aria-hidden="true"></i> MySQL
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-solid fa-vial text-sage-200" aria-hidden="true"></i> Jest
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-brands fa-aws text-sage-200" aria-hidden="true"></i> AWS
+      </span>
+      <span class="skill-pill inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-ivory border border-sage/40 text-sm font-mono dark:bg-charcoal-50/40">
+        <i class="fa-brands fa-python text-sage-200" aria-hidden="true"></i> Python
+      </span>
+    </div>
+
+    <p class="mt-8 font-mono text-xs text-charcoal-50/70 dark:text-ivory-200/60">// always learning &mdash; currently exploring observability, distributed tracing, and Rust</p>
+  </div>
+</section>
+
+<!-- ===================== CONTACT ===================== -->
+<section id="contact" class="bg-ivory-200 dark:bg-[#221E18] py-24 sm:py-32 border-t border-ivory-300/70 dark:border-charcoal-50/30">
+  <div class="max-w-content mx-auto px-5 sm:px-8">
+
+    <div class="grid lg:grid-cols-12 gap-12 mb-14">
+      <div class="lg:col-span-3 reveal">
+        <span class="font-mono text-sage-200 dark:text-sage text-sm num-rule">05 / Contact</span>
+        <p class="font-script text-2xl text-sage-200 dark:text-sage mt-3">say hello.</p>
+      </div>
+      <div class="lg:col-span-9 reveal">
+        <h2 class="font-display text-4xl sm:text-5xl leading-tight font-medium tracking-tight">Have a system worth building?</h2>
+        <p class="mt-4 max-w-2xl text-charcoal-50 dark:text-ivory-200/80">I'm open to senior engineering roles &mdash; remote, hybrid, or on-site for the right team. Drop a line.</p>
+      </div>
+    </div>
+
+    <div class="grid lg:grid-cols-12 gap-10 lg:gap-16">
+      <!-- Info column -->
+      <div class="lg:col-span-5 space-y-6 reveal">
+        <a href="mailto:rafatahmedorik@gmail.com" class="cta-lift flex items-start gap-4 p-5 rounded-2xl border border-sage/30 bg-ivory dark:bg-charcoal-50/40 hover:border-sage hover:shadow-soft">
+          <div class="w-11 h-11 grid place-items-center rounded-xl bg-sage/15 text-sage-200 dark:text-sage shrink-0" aria-hidden="true">
+            <i class="fa-regular fa-envelope"></i>
+          </div>
+          <div class="min-w-0">
+            <div class="font-mono text-[11px] uppercase tracking-wider text-sage-200 dark:text-sage">Email</div>
+            <div class="text-sm sm:text-base font-medium break-all">rafatahmedorik@gmail.com</div>
+          </div>
+        </a>
+
+        <a href="tel:+8801911750945" class="cta-lift flex items-start gap-4 p-5 rounded-2xl border border-sage/30 bg-ivory dark:bg-charcoal-50/40 hover:border-sage hover:shadow-soft">
+          <div class="w-11 h-11 grid place-items-center rounded-xl bg-sage/15 text-sage-200 dark:text-sage shrink-0" aria-hidden="true">
+            <i class="fa-solid fa-phone"></i>
+          </div>
+          <div>
+            <div class="font-mono text-[11px] uppercase tracking-wider text-sage-200 dark:text-sage">Phone</div>
+            <div class="text-sm sm:text-base font-medium">+880 (1911) 750-945</div>
+          </div>
+        </a>
+
+        <div class="flex items-start gap-4 p-5 rounded-2xl border border-sage/30 bg-ivory dark:bg-charcoal-50/40">
+          <div class="w-11 h-11 grid place-items-center rounded-xl bg-sage/15 text-sage-200 dark:text-sage shrink-0" aria-hidden="true">
+            <i class="fa-solid fa-location-dot"></i>
+          </div>
+          <div>
+            <div class="font-mono text-[11px] uppercase tracking-wider text-sage-200 dark:text-sage">Based in</div>
+            <div class="text-sm sm:text-base font-medium">Dhaka, Bangladesh</div>
+            <div class="text-xs text-charcoal-50 dark:text-ivory-200/70 mt-0.5">Open to remote &middot; UTC+6</div>
+          </div>
+        </div>
+
+        <!-- Socials -->
+        <div class="pt-2">
+          <div class="font-mono text-[11px] uppercase tracking-wider text-sage-200 dark:text-sage mb-3">Find me online</div>
+          <div class="flex items-center gap-3">
+            <a href="https://github.com/rafat69ahmed" target="_blank" rel="noopener" aria-label="GitHub" class="cta-lift w-11 h-11 grid place-items-center rounded-full border border-sage/40 hover:bg-sage hover:text-ivory hover:border-sage">
+              <i class="fa-brands fa-github"></i>
+            </a>
+            <a href="https://linkedin.com/in/rafat69ahmed/" target="_blank" rel="noopener" aria-label="LinkedIn" class="cta-lift w-11 h-11 grid place-items-center rounded-full border border-sage/40 hover:bg-sage hover:text-ivory hover:border-sage">
+              <i class="fa-brands fa-linkedin-in"></i>
+            </a>
+            <a href="https://facebook.com/rafat.ahmed.146" target="_blank" rel="noopener" aria-label="Facebook" class="cta-lift w-11 h-11 grid place-items-center rounded-full border border-sage/40 hover:bg-sage hover:text-ivory hover:border-sage">
+              <i class="fa-brands fa-facebook-f"></i>
+            </a>
+          </div>
+        </div>
+      </div>
+
+      <!-- Form column -->
+      <div class="lg:col-span-7 reveal">
+        <form id="contact-form" novalidate class="rounded-2xl border border-sage/30 bg-ivory dark:bg-charcoal-50/40 p-6 sm:p-10 shadow-soft">
+          <div class="grid sm:grid-cols-2 gap-5">
+            <div>
+              <label for="cf-name" class="block font-mono text-[12px] uppercase tracking-wider text-sage-200 dark:text-sage mb-1.5">Name <span class="text-terracotta">*</span></label>
+              <input id="cf-name" name="name" type="text" autocomplete="name" required minlength="2" class="field" placeholder="Your name" aria-describedby="cf-name-err" />
+              <p id="cf-name-err" class="hidden mt-1.5 text-xs text-terracotta">Please enter your name (at least 2 characters).</p>
+            </div>
+            <div>
+              <label for="cf-email" class="block font-mono text-[12px] uppercase tracking-wider text-sage-200 dark:text-sage mb-1.5">Email <span class="text-terracotta">*</span></label>
+              <input id="cf-email" name="email" type="email" autocomplete="email" required class="field" placeholder="you@company.com" aria-describedby="cf-email-err" />
+              <p id="cf-email-err" class="hidden mt-1.5 text-xs text-terracotta">Please enter a valid email address.</p>
+            </div>
+          </div>
+          <div class="mt-5">
+            <label for="cf-subject" class="block font-mono text-[12px] uppercase tracking-wider text-sage-200 dark:text-sage mb-1.5">Subject</label>
+            <input id="cf-subject" name="subject" type="text" class="field" placeholder="What's this about?" />
+          </div>
+          <div class="mt-5">
+            <label for="cf-message" class="block font-mono text-[12px] uppercase tracking-wider text-sage-200 dark:text-sage mb-1.5">Message <span class="text-terracotta">*</span></label>
+            <textarea id="cf-message" name="message" rows="5" required minlength="10" class="field resize-y" placeholder="Tell me a bit about the project, role, or idea." aria-describedby="cf-message-err"></textarea>
+            <p id="cf-message-err" class="hidden mt-1.5 text-xs text-terracotta">Please write at least 10 characters.</p>
+          </div>
+
+          <div class="mt-7 flex flex-wrap items-center justify-between gap-4">
+            <p class="font-mono text-[11px] text-charcoal-50/70 dark:text-ivory-200/60">// I usually reply within 24 hours.</p>
+            <button type="submit" id="cf-submit" class="cta-lift inline-flex items-center gap-2 px-6 py-3 rounded-full bg-charcoal text-ivory hover:bg-sage-200 dark:bg-ivory dark:text-charcoal dark:hover:bg-sage hover:shadow-lift font-medium text-sm">
+              <span id="cf-submit-label">Send message</span>
+              <i id="cf-submit-icon" class="fa-solid fa-paper-plane text-xs"></i>
+            </button>
+          </div>
+
+          <!-- Success state -->
+          <div id="cf-success" role="status" aria-live="polite" class="hidden mt-5 p-4 rounded-xl border border-sage/40 bg-sage/10 text-sm">
+            <i class="fa-solid fa-circle-check text-sage-200 dark:text-sage mr-2"></i>
+            Thanks &mdash; your message is on its way. I'll get back to you shortly.
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</section>
+
+</main>
+
+<!-- ===================== FOOTER ===================== -->
+<footer class="border-t border-ivory-300 dark:border-charcoal-50/40 py-10">
+  <div class="max-w-content mx-auto px-5 sm:px-8 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+    <div class="flex items-center gap-3">
+      <span class="font-display text-lg">Rafat Ahmed</span>
+      <span class="font-mono text-xs text-charcoal-50/70 dark:text-ivory-200/60">&middot; Senior Software Engineer</span>
+    </div>
+    <p class="font-mono text-xs text-charcoal-50/70 dark:text-ivory-200/60">
+      &copy; <span id="year">2026</span> &middot; Crafted in Dhaka with care.
+    </p>
+  </div>
+</footer>
+
+<!-- Scroll-to-top -->
+<button id="to-top" aria-label="Scroll to top" class="cta-lift fixed bottom-6 right-6 w-12 h-12 rounded-full bg-charcoal text-ivory dark:bg-ivory dark:text-charcoal grid place-items-center shadow-lift opacity-0 pointer-events-none translate-y-3 transition-all">
+  <i class="fa-solid fa-arrow-up text-sm"></i>
+</button>
+
+<script>
+(function () {
+  // ======= Theme =======
+  const THEME_KEY = 'rafat-theme-b';
+  const root = document.documentElement;
+  const stored = localStorage.getItem(THEME_KEY);
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  if (stored === 'dark' || (!stored && prefersDark)) root.classList.add('dark');
+  document.getElementById('theme-toggle').addEventListener('click', function () {
+    root.classList.toggle('dark');
+    localStorage.setItem(THEME_KEY, root.classList.contains('dark') ? 'dark' : 'light');
+  });
+
+  // ======= Mobile menu =======
+  const menuBtn = document.getElementById('menu-toggle');
+  const menu = document.getElementById('mobile-menu');
+  menuBtn.addEventListener('click', function () {
+    const open = menu.classList.toggle('open');
+    menuBtn.setAttribute('aria-expanded', String(open));
+  });
+  menu.querySelectorAll('a').forEach(function (a) {
+    a.addEventListener('click', function () {
+      menu.classList.remove('open');
+      menuBtn.setAttribute('aria-expanded', 'false');
+    });
+  });
+
+  // ======= Year =======
+  document.getElementById('year').textContent = new Date().getFullYear();
+
+  // ======= Reveal on scroll + section number underline =======
+  if ('IntersectionObserver' in window) {
+    const io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) {
+          e.target.classList.add('in-view');
+          io.unobserve(e.target);
+        }
+      });
+    }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' });
+    document.querySelectorAll('.reveal, .num-rule').forEach(function (el) { io.observe(el); });
+  } else {
+    document.querySelectorAll('.reveal, .num-rule').forEach(function (el) { el.classList.add('in-view'); });
+  }
+
+  // ======= Scroll-to-top =======
+  const toTop = document.getElementById('to-top');
+  window.addEventListener('scroll', function () {
+    if (window.scrollY > 600) {
+      toTop.classList.remove('opacity-0', 'pointer-events-none', 'translate-y-3');
+    } else {
+      toTop.classList.add('opacity-0', 'pointer-events-none', 'translate-y-3');
+    }
+  }, { passive: true });
+  toTop.addEventListener('click', function () {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+
+  // ======= Contact form =======
+  const form = document.getElementById('contact-form');
+  const nameI = document.getElementById('cf-name');
+  const emailI = document.getElementById('cf-email');
+  const msgI = document.getElementById('cf-message');
+  const nameErr = document.getElementById('cf-name-err');
+  const emailErr = document.getElementById('cf-email-err');
+  const msgErr = document.getElementById('cf-message-err');
+  const submitBtn = document.getElementById('cf-submit');
+  const submitLabel = document.getElementById('cf-submit-label');
+  const submitIcon = document.getElementById('cf-submit-icon');
+  const success = document.getElementById('cf-success');
+
+  function setInvalid(input, errEl, isInvalid) {
+    if (isInvalid) {
+      input.classList.add('invalid');
+      errEl.classList.remove('hidden');
+      input.setAttribute('aria-invalid', 'true');
+    } else {
+      input.classList.remove('invalid');
+      errEl.classList.add('hidden');
+      input.removeAttribute('aria-invalid');
+    }
+  }
+  function emailValid(v) { return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v); }
+
+  // Inline validation on blur
+  nameI.addEventListener('blur', function () { setInvalid(nameI, nameErr, nameI.value.trim().length < 2); });
+  emailI.addEventListener('blur', function () { setInvalid(emailI, emailErr, !emailValid(emailI.value.trim())); });
+  msgI.addEventListener('blur', function () { setInvalid(msgI, msgErr, msgI.value.trim().length < 10); });
+
+  form.addEventListener('submit', function (e) {
+    e.preventDefault();
+    const nBad = nameI.value.trim().length < 2;
+    const eBad = !emailValid(emailI.value.trim());
+    const mBad = msgI.value.trim().length < 10;
+    setInvalid(nameI, nameErr, nBad);
+    setInvalid(emailI, emailErr, eBad);
+    setInvalid(msgI, msgErr, mBad);
+    if (nBad || eBad || mBad) {
+      const first = nBad ? nameI : eBad ? emailI : msgI;
+      first.focus();
+      return;
+    }
+    // Simulate submit
+    submitBtn.disabled = true;
+    submitLabel.textContent = 'Sending...';
+    submitIcon.className = 'fa-solid fa-circle-notch fa-spin text-xs';
+    setTimeout(function () {
+      success.classList.remove('hidden');
+      submitLabel.textContent = 'Sent!';
+      submitIcon.className = 'fa-solid fa-check text-xs';
+      form.reset();
+      setTimeout(function () {
+        submitBtn.disabled = false;
+        submitLabel.textContent = 'Send message';
+        submitIcon.className = 'fa-solid fa-paper-plane text-xs';
+        success.classList.add('hidden');
+      }, 4000);
+    }, 900);
+  });
+})();
+</script>
+</body>
+</html>

--- a/option-c.html
+++ b/option-c.html
@@ -1,0 +1,1191 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Rafat Ahmed — Senior Software Engineer. Editorial portfolio. Backend architecture, microservices, scalable web infrastructure. Dhaka, Bangladesh." />
+  <meta name="theme-color" content="#F5F2EC" />
+  <title>Rafat Ahmed — Senior Software Engineer / Editorial Folio</title>
+  <link rel="icon" href="../../../assets/images/favicon.ico" type="image/x-icon" />
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter+Tight:wght@300;400;500;600;700&family=JetBrains+Mono:wght@300;400;500;600&display=swap" rel="stylesheet" />
+
+  <!-- Tailwind CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            paper: { DEFAULT: '#F5F2EC', dark: '#E8E5DD' },
+            ink:   { DEFAULT: '#0F0F0F', dark: '#0A0A0A' },
+            coral: { DEFAULT: '#FF5436', deep: '#E63B1E' },
+            sage:  { DEFAULT: '#5A6B5C', light: '#8AA08D' },
+            mute:  { DEFAULT: '#6B6B6B', dark: '#9A9A92' }
+          },
+          fontFamily: {
+            serif: ['"Instrument Serif"', 'Georgia', 'serif'],
+            sans:  ['"Inter Tight"', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            mono:  ['"JetBrains Mono"', 'ui-monospace', 'monospace']
+          },
+          letterSpacing: {
+            'mono-wide': '0.18em',
+            'mono-extra': '0.28em',
+            'serif-tight': '-0.025em',
+            'serif-extra-tight': '-0.04em'
+          }
+        }
+      }
+    };
+  </script>
+
+  <style>
+    /* ---------- Base ---------- */
+    html, body { background-color: #F5F2EC; color: #0F0F0F; }
+    html.dark, html.dark body { background-color: #0A0A0A; color: #E8E5DD; }
+    body {
+      font-family: '"Inter Tight"', system-ui, sans-serif;
+      font-size: 16px;
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      text-rendering: optimizeLegibility;
+    }
+
+    /* ---------- Display serif ---------- */
+    .font-display { font-family: '"Instrument Serif"', Georgia, serif; line-height: 1.04; letter-spacing: -0.025em; }
+    .font-display-italic { font-family: '"Instrument Serif"', Georgia, serif; font-style: italic; }
+
+    /* ---------- Mono small caps / kicker ---------- */
+    .kicker {
+      font-family: '"JetBrains Mono"', ui-monospace, monospace;
+      font-size: 0.72rem;
+      letter-spacing: 0.22em;
+      text-transform: uppercase;
+      font-weight: 500;
+    }
+    .label-mono {
+      font-family: '"JetBrains Mono"', ui-monospace, monospace;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      font-size: 0.7rem;
+    }
+    .section-num {
+      font-family: '"JetBrains Mono"', ui-monospace, monospace;
+      letter-spacing: 0.2em;
+      font-size: 0.78rem;
+      text-transform: uppercase;
+    }
+
+    /* ---------- Coral underline link (draws from left on hover) ---------- */
+    .ulink {
+      position: relative;
+      display: inline-block;
+      padding-bottom: 2px;
+    }
+    .ulink::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      width: 100%;
+      height: 1px;
+      background-color: #FF5436;
+      transform: scaleX(0);
+      transform-origin: left;
+      transition: transform 250ms cubic-bezier(0.22, 0.61, 0.36, 1);
+    }
+    .ulink:hover::after,
+    .ulink:focus-visible::after { transform: scaleX(1); }
+
+    /* ---------- Nav link active dot ---------- */
+    .nav-link {
+      position: relative;
+      transition: color 200ms ease-out;
+    }
+    .nav-link:hover { color: #FF5436; }
+
+    /* ---------- Coral arrow translate ---------- */
+    .arrow-link { display: inline-flex; align-items: center; gap: 0.5rem; }
+    .arrow-link .arrow {
+      display: inline-block;
+      transition: transform 250ms cubic-bezier(0.22, 0.61, 0.36, 1);
+    }
+    .arrow-link:hover .arrow,
+    .arrow-link:focus-visible .arrow { transform: translateX(6px); }
+
+    /* ---------- Pulsing coral dot ---------- */
+    .pulse-dot {
+      width: 8px; height: 8px; border-radius: 9999px;
+      background: #FF5436;
+      box-shadow: 0 0 0 0 rgba(255, 84, 54, 0.55);
+      animation: pulse 2.2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+    }
+    @keyframes pulse {
+      0%   { box-shadow: 0 0 0 0 rgba(255, 84, 54, 0.55); }
+      70%  { box-shadow: 0 0 0 14px rgba(255, 84, 54, 0); }
+      100% { box-shadow: 0 0 0 0 rgba(255, 84, 54, 0); }
+    }
+
+    /* ---------- Reveal on scroll ---------- */
+    .reveal {
+      opacity: 0;
+      transform: translateY(18px);
+      transition: opacity 600ms cubic-bezier(0.22, 0.61, 0.36, 1), transform 600ms cubic-bezier(0.22, 0.61, 0.36, 1);
+      will-change: opacity, transform;
+    }
+    .reveal.visible { opacity: 1; transform: translateY(0); }
+
+    /* ---------- Project image hover (subtle desat) ---------- */
+    .img-hover {
+      transition: filter 350ms ease-out, transform 500ms cubic-bezier(0.22, 0.61, 0.36, 1);
+      filter: saturate(1);
+    }
+    .img-hover:hover { filter: saturate(0.7) contrast(1.02); transform: scale(1.005); }
+
+    /* ---------- Hero portrait rotation ---------- */
+    .portrait-rot { transform: rotate(-1.5deg); transition: transform 400ms ease-out; }
+    .portrait-rot:hover { transform: rotate(0deg); }
+
+    /* ---------- Drop cap ---------- */
+    .dropcap::first-letter {
+      font-family: '"Instrument Serif"', Georgia, serif;
+      font-size: 4.4rem;
+      line-height: 0.85;
+      float: left;
+      padding: 0.32rem 0.55rem 0 0;
+      color: #FF5436;
+      font-weight: 400;
+    }
+
+    /* ---------- Hairline rule ---------- */
+    .hairline {
+      height: 1px; width: 100%;
+      background: rgba(15, 15, 15, 0.18);
+    }
+    html.dark .hairline { background: rgba(232, 229, 221, 0.16); }
+
+    /* ---------- Focus rings ---------- */
+    a:focus-visible, button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible {
+      outline: 2px solid #FF5436;
+      outline-offset: 3px;
+      border-radius: 1px;
+    }
+
+    /* ---------- Selection ---------- */
+    ::selection { background: #FF5436; color: #F5F2EC; }
+    html.dark ::selection { background: #FF5436; color: #0A0A0A; }
+
+    /* ---------- Marquee divider ---------- */
+    .marquee-track {
+      display: flex;
+      gap: 3rem;
+      animation: marquee 40s linear infinite;
+      will-change: transform;
+    }
+    @keyframes marquee {
+      from { transform: translateX(0); }
+      to   { transform: translateX(-50%); }
+    }
+
+    /* ---------- Form ---------- */
+    .field-input {
+      width: 100%;
+      background: transparent;
+      border: 0;
+      border-bottom: 1px solid rgba(15,15,15,0.2);
+      padding: 14px 0 12px;
+      font-family: '"Inter Tight"', sans-serif;
+      font-size: 16px; /* prevent iOS zoom */
+      color: inherit;
+      transition: border-color 200ms ease-out;
+      min-height: 48px;
+    }
+    .field-input:focus { outline: none; border-bottom-color: #FF5436; }
+    html.dark .field-input { border-bottom-color: rgba(232,229,221,0.22); }
+    html.dark .field-input:focus { border-bottom-color: #FF5436; }
+
+    /* ---------- Mobile menu ---------- */
+    .mobile-menu {
+      transform: translateX(100%);
+      transition: transform 320ms cubic-bezier(0.22, 0.61, 0.36, 1);
+    }
+    .mobile-menu.open { transform: translateX(0); }
+
+    /* ---------- Scroll-to-top ---------- */
+    .to-top {
+      opacity: 0; pointer-events: none;
+      transition: opacity 250ms ease-out, transform 250ms ease-out;
+    }
+    .to-top.visible { opacity: 1; pointer-events: auto; }
+    .to-top:hover { transform: translateY(-3px); }
+
+    /* ---------- Reduced motion ---------- */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
+      .reveal { opacity: 1; transform: none; }
+      .pulse-dot { box-shadow: none; animation: none; }
+      .marquee-track { animation: none; }
+    }
+
+    /* ---------- Touch targets for nav ---------- */
+    .nav-link { padding: 8px 4px; min-height: 44px; display: inline-flex; align-items: center; }
+
+    /* ---------- Dark surface utility ---------- */
+    html.dark .bg-paper { background-color: #0A0A0A !important; }
+
+    /* ---------- Container ---------- */
+    .container-edit {
+      max-width: 1440px;
+      margin-left: auto;
+      margin-right: auto;
+      padding-left: 1.25rem;
+      padding-right: 1.25rem;
+    }
+    @media (min-width: 768px) { .container-edit { padding-left: 2.5rem; padding-right: 2.5rem; } }
+    @media (min-width: 1024px) { .container-edit { padding-left: 4rem; padding-right: 4rem; } }
+    @media (min-width: 1280px) { .container-edit { padding-left: 5.5rem; padding-right: 5.5rem; } }
+
+    /* ---------- Hero scale ---------- */
+    .hero-headline {
+      font-size: clamp(2.6rem, 9.5vw, 9.5rem);
+      line-height: 0.96;
+      letter-spacing: -0.035em;
+    }
+    .section-headline {
+      font-size: clamp(2.4rem, 6.5vw, 6rem);
+      line-height: 1.02;
+      letter-spacing: -0.028em;
+    }
+    .signoff {
+      font-size: clamp(3rem, 11vw, 11rem);
+      line-height: 0.95;
+      letter-spacing: -0.04em;
+    }
+
+    /* ---------- Skip link ---------- */
+    .skip-link {
+      position: absolute;
+      left: -9999px;
+      top: 0;
+      background: #0F0F0F;
+      color: #F5F2EC;
+      padding: 12px 16px;
+      font-family: '"JetBrains Mono"', monospace;
+      font-size: 0.78rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      z-index: 100;
+    }
+    .skip-link:focus { left: 12px; top: 12px; }
+  </style>
+</head>
+
+<body class="bg-paper text-ink dark:bg-ink-dark dark:text-paper-dark antialiased">
+
+  <a href="#main" class="skip-link">Skip to content</a>
+
+  <!-- ============================================================
+       HEADER
+  ============================================================ -->
+  <header id="site-header" class="fixed top-0 left-0 right-0 z-40 bg-paper/85 dark:bg-ink-dark/85 backdrop-blur-md border-b border-ink/10 dark:border-paper-dark/15">
+    <div class="container-edit flex items-center justify-between h-16 md:h-20">
+
+      <!-- Brand -->
+      <a href="#hero" class="flex items-center gap-3 group" aria-label="Rafat Ahmed — Home">
+        <span class="font-mono text-[0.72rem] tracking-mono-wide uppercase">
+          <span class="text-coral">§</span> Rafat Ahmed
+        </span>
+        <span class="hidden md:inline-block label-mono text-mute dark:text-mute-dark">Editorial Folio /// 2026</span>
+      </a>
+
+      <!-- Desktop Nav -->
+      <nav class="hidden md:flex items-center gap-8" aria-label="Primary">
+        <a href="#about" class="nav-link label-mono">01 About</a>
+        <a href="#experience" class="nav-link label-mono">02 Work</a>
+        <a href="#projects" class="nav-link label-mono">03 Shipping</a>
+        <a href="#skills" class="nav-link label-mono">04 Stack</a>
+        <a href="#contact" class="nav-link label-mono">05 Contact</a>
+      </nav>
+
+      <!-- Right cluster -->
+      <div class="flex items-center gap-3">
+        <button id="theme-toggle" type="button" aria-label="Toggle dark mode" class="w-11 h-11 flex items-center justify-center rounded-full border border-ink/15 dark:border-paper-dark/20 hover:border-coral hover:text-coral transition-colors">
+          <!-- sun -->
+          <svg id="icon-sun" class="hidden dark:block w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+          <!-- moon -->
+          <svg id="icon-moon" class="block dark:hidden w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        </button>
+
+        <a href="../../../assets/documents/rafat_ahmed_cv.pdf" download class="hidden md:inline-flex items-center gap-2 label-mono px-4 h-11 border border-ink/20 dark:border-paper-dark/25 hover:bg-ink hover:text-paper dark:hover:bg-paper-dark dark:hover:text-ink-dark transition-colors">
+          CV.pdf
+          <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M5 12l7 7 7-7"/></svg>
+        </a>
+
+        <button id="menu-open" type="button" aria-label="Open menu" aria-controls="mobile-menu" aria-expanded="false" class="md:hidden w-11 h-11 flex flex-col items-center justify-center gap-1.5">
+          <span class="block w-5 h-px bg-current"></span>
+          <span class="block w-5 h-px bg-current"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <!-- ============================================================
+       MOBILE MENU OVERLAY
+  ============================================================ -->
+  <div id="mobile-menu" class="mobile-menu fixed inset-0 z-50 bg-paper dark:bg-ink-dark md:hidden" role="dialog" aria-modal="true" aria-label="Mobile menu">
+    <div class="container-edit h-16 flex items-center justify-between border-b border-ink/10 dark:border-paper-dark/15">
+      <span class="font-mono text-[0.72rem] tracking-mono-wide uppercase"><span class="text-coral">§</span> Menu</span>
+      <button id="menu-close" type="button" aria-label="Close menu" class="w-11 h-11 flex items-center justify-center">
+        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"/></svg>
+      </button>
+    </div>
+    <nav class="container-edit pt-12 pb-10 flex flex-col" aria-label="Mobile primary">
+      <a href="#about" class="mobile-link group flex items-baseline justify-between border-b border-ink/10 dark:border-paper-dark/12 py-6">
+        <span class="font-display text-5xl">About</span>
+        <span class="label-mono text-mute group-hover:text-coral">§ 01</span>
+      </a>
+      <a href="#experience" class="mobile-link group flex items-baseline justify-between border-b border-ink/10 dark:border-paper-dark/12 py-6">
+        <span class="font-display text-5xl">Work</span>
+        <span class="label-mono text-mute group-hover:text-coral">§ 02</span>
+      </a>
+      <a href="#projects" class="mobile-link group flex items-baseline justify-between border-b border-ink/10 dark:border-paper-dark/12 py-6">
+        <span class="font-display text-5xl">Shipping</span>
+        <span class="label-mono text-mute group-hover:text-coral">§ 03</span>
+      </a>
+      <a href="#skills" class="mobile-link group flex items-baseline justify-between border-b border-ink/10 dark:border-paper-dark/12 py-6">
+        <span class="font-display text-5xl">Stack</span>
+        <span class="label-mono text-mute group-hover:text-coral">§ 04</span>
+      </a>
+      <a href="#contact" class="mobile-link group flex items-baseline justify-between border-b border-ink/10 dark:border-paper-dark/12 py-6">
+        <span class="font-display text-5xl">Contact</span>
+        <span class="label-mono text-mute group-hover:text-coral">§ 05</span>
+      </a>
+
+      <a href="../../../assets/documents/rafat_ahmed_cv.pdf" download class="mt-10 inline-flex items-center justify-between label-mono border border-ink/25 dark:border-paper-dark/25 h-12 px-5 hover:bg-coral hover:border-coral hover:text-paper transition-colors">
+        Download CV.pdf
+        <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M5 12l7 7 7-7"/></svg>
+      </a>
+    </nav>
+  </div>
+
+  <!-- ============================================================
+       MAIN
+  ============================================================ -->
+  <main id="main">
+
+    <!-- ============================================================
+         HERO — § COVER
+    ============================================================ -->
+    <section id="hero" class="relative pt-28 md:pt-36 pb-20 md:pb-28">
+      <div class="container-edit">
+
+        <!-- Top meta strip -->
+        <div class="flex flex-wrap items-center justify-between gap-4 mb-12 md:mb-20">
+          <div class="flex items-center gap-3">
+            <span class="pulse-dot" aria-hidden="true"></span>
+            <span class="label-mono text-ink dark:text-paper-dark">Available for new opportunities — Dhaka, BD</span>
+          </div>
+          <div class="hidden md:flex items-center gap-6">
+            <span class="label-mono text-mute dark:text-mute-dark">Issue 026 / Vol. IX</span>
+            <span class="label-mono text-mute dark:text-mute-dark">Spring 2026</span>
+          </div>
+        </div>
+
+        <!-- Cover grid -->
+        <div class="grid grid-cols-12 gap-6 md:gap-10 items-start">
+
+          <!-- Headline -->
+          <div class="col-span-12 lg:col-span-8 order-2 lg:order-1">
+            <p class="kicker text-coral mb-6">§ Cover / The Senior Engineer</p>
+            <h1 class="font-display hero-headline">
+              <span class="block">Senior software</span>
+              <span class="block">engineer building</span>
+              <span class="block">
+                <span class="font-display-italic text-coral">scalable</span> web infrastructure.
+              </span>
+            </h1>
+
+            <div class="mt-10 md:mt-14 grid grid-cols-12 gap-6">
+              <div class="col-span-12 md:col-span-7">
+                <p class="text-lg md:text-xl leading-relaxed text-ink/80 dark:text-paper-dark/80" style="max-width: 60ch;">
+                  Nine years across backend architecture, microservices and the messy middle where systems meet people. Currently shipping multi-vendor commerce and real-time auctions for <span class="font-display-italic">Vendidit</span>.
+                </p>
+              </div>
+              <div class="col-span-12 md:col-span-5 md:pl-6 md:border-l border-ink/15 dark:border-paper-dark/15">
+                <dl class="space-y-3">
+                  <div class="flex items-baseline justify-between">
+                    <dt class="label-mono text-mute dark:text-mute-dark">Based</dt>
+                    <dd class="font-mono text-sm">Dhaka, BD</dd>
+                  </div>
+                  <div class="flex items-baseline justify-between">
+                    <dt class="label-mono text-mute dark:text-mute-dark">Experience</dt>
+                    <dd class="font-mono text-sm">9+ years</dd>
+                  </div>
+                  <div class="flex items-baseline justify-between">
+                    <dt class="label-mono text-mute dark:text-mute-dark">Focus</dt>
+                    <dd class="font-mono text-sm">Backend / Microservices</dd>
+                  </div>
+                  <div class="flex items-baseline justify-between">
+                    <dt class="label-mono text-mute dark:text-mute-dark">Status</dt>
+                    <dd class="font-mono text-sm text-coral">Open to roles</dd>
+                  </div>
+                </dl>
+              </div>
+            </div>
+
+            <div class="mt-12 flex flex-wrap items-center gap-4">
+              <a href="#projects" class="arrow-link inline-flex items-center gap-3 label-mono bg-ink text-paper dark:bg-paper-dark dark:text-ink-dark h-12 px-6 hover:bg-coral hover:text-paper transition-colors">
+                View Selected Work
+                <span class="arrow">&rarr;</span>
+              </a>
+              <a href="#contact" class="arrow-link label-mono h-12 px-6 inline-flex items-center border border-ink/25 dark:border-paper-dark/25 hover:border-coral hover:text-coral transition-colors">
+                Start a Conversation
+                <span class="arrow">&rarr;</span>
+              </a>
+            </div>
+          </div>
+
+          <!-- Portrait -->
+          <div class="col-span-12 lg:col-span-4 order-1 lg:order-2">
+            <figure class="relative">
+              <div class="aspect-square overflow-hidden border border-ink/15 dark:border-paper-dark/20 portrait-rot bg-ink/5 dark:bg-paper-dark/10">
+                <img src="../../../assets/images/profile.jpg" alt="Portrait of Rafat Ahmed, Senior Software Engineer based in Dhaka, Bangladesh." width="640" height="640" class="w-full h-full object-cover img-hover" loading="eager" decoding="async" />
+              </div>
+              <figcaption class="mt-4 flex items-start justify-between gap-4">
+                <span class="label-mono text-mute dark:text-mute-dark">Plate I — <span class="text-ink dark:text-paper-dark">Rafat Ahmed</span></span>
+                <span class="label-mono text-mute dark:text-mute-dark">Photo / 2026</span>
+              </figcaption>
+            </figure>
+          </div>
+
+        </div>
+      </div>
+
+      <!-- Bottom hairline + scroll cue -->
+      <div class="container-edit mt-20 md:mt-28">
+        <div class="hairline"></div>
+        <div class="flex items-center justify-between pt-5">
+          <span class="label-mono text-mute dark:text-mute-dark">Scroll to read</span>
+          <span class="label-mono text-mute dark:text-mute-dark">P. 01</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================================
+         MARQUEE STRIP
+    ============================================================ -->
+    <section aria-hidden="true" class="overflow-hidden border-y border-ink/15 dark:border-paper-dark/15 py-5 bg-paper dark:bg-ink-dark">
+      <div class="marquee-track whitespace-nowrap">
+        <div class="flex items-center gap-12 label-mono text-mute dark:text-mute-dark">
+          <span>Microservices</span><span class="text-coral">&bull;</span>
+          <span>Node.js / NestJS</span><span class="text-coral">&bull;</span>
+          <span>PostgreSQL</span><span class="text-coral">&bull;</span>
+          <span>AWS &amp; Lambda</span><span class="text-coral">&bull;</span>
+          <span>Test-Driven Development</span><span class="text-coral">&bull;</span>
+          <span>Docker</span><span class="text-coral">&bull;</span>
+          <span>Backend Architecture</span><span class="text-coral">&bull;</span>
+          <span>9+ Years Shipping</span><span class="text-coral">&bull;</span>
+        </div>
+        <div class="flex items-center gap-12 label-mono text-mute dark:text-mute-dark" aria-hidden="true">
+          <span>Microservices</span><span class="text-coral">&bull;</span>
+          <span>Node.js / NestJS</span><span class="text-coral">&bull;</span>
+          <span>PostgreSQL</span><span class="text-coral">&bull;</span>
+          <span>AWS &amp; Lambda</span><span class="text-coral">&bull;</span>
+          <span>Test-Driven Development</span><span class="text-coral">&bull;</span>
+          <span>Docker</span><span class="text-coral">&bull;</span>
+          <span>Backend Architecture</span><span class="text-coral">&bull;</span>
+          <span>9+ Years Shipping</span><span class="text-coral">&bull;</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================================
+         ABOUT — § 01
+    ============================================================ -->
+    <section id="about" class="py-28 md:py-40 scroll-mt-24">
+      <div class="container-edit">
+        <div class="grid grid-cols-12 gap-6 md:gap-10">
+
+          <!-- Section header -->
+          <div class="col-span-12 lg:col-span-12 mb-12 md:mb-20 reveal">
+            <div class="flex items-center justify-between mb-6">
+              <span class="section-num text-coral">§ 01 / About</span>
+              <span class="section-num text-mute dark:text-mute-dark">P. 02</span>
+            </div>
+            <h2 class="font-display section-headline">
+              A backend architect, <span class="font-display-italic">first.</span>
+            </h2>
+            <p class="kicker mt-6 text-mute dark:text-mute-dark">An introduction — Nine years, three continents of clients, one obsession.</p>
+          </div>
+
+          <!-- Body grid -->
+          <div class="col-span-12 lg:col-span-7 reveal">
+            <p class="dropcap text-base md:text-lg leading-[1.7] text-ink/85 dark:text-paper-dark/85" style="max-width: 65ch;">
+              Experienced software engineer and backend architect with over nine years of industry expertise spanning diverse domains, platforms and systems. For the past seven years I have been fully immersed in web development, bringing robust architectural thinking and scalable system design to every project I touch.
+            </p>
+            <p class="mt-6 text-base md:text-lg leading-[1.7] text-ink/85 dark:text-paper-dark/85" style="max-width: 65ch;">
+              I specialize in backend architecture and possess efficient knowledge of frontend architecture. My passion lies in designing reliable, maintainable infrastructures that align with modern best practices &mdash; test-driven development, disciplined Git Flow, and containerization with Docker. My background also includes hands-on experience in product research and management, giving me a well-rounded perspective on building and delivering impactful software.
+            </p>
+
+            <div class="mt-10 grid grid-cols-3 gap-6 max-w-md">
+              <div>
+                <div class="font-display text-5xl text-coral leading-none">9+</div>
+                <div class="label-mono text-mute dark:text-mute-dark mt-2">Years</div>
+              </div>
+              <div>
+                <div class="font-display text-5xl leading-none">5M</div>
+                <div class="label-mono text-mute dark:text-mute-dark mt-2">Subscribers reached</div>
+              </div>
+              <div>
+                <div class="font-display text-5xl leading-none">82.4%</div>
+                <div class="label-mono text-mute dark:text-mute-dark mt-2">Test coverage</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Right column: about image + meta -->
+          <div class="col-span-12 lg:col-span-5 lg:pl-8 reveal">
+            <figure>
+              <div class="aspect-[4/3] overflow-hidden border border-ink/15 dark:border-paper-dark/20 bg-ink/5 dark:bg-paper-dark/10">
+                <img src="../../../assets/images/about.png" alt="Illustration: developer at work, representing Rafat's craft and process." width="800" height="600" class="w-full h-full object-cover img-hover" loading="lazy" decoding="async" />
+              </div>
+              <figcaption class="label-mono text-mute dark:text-mute-dark mt-4 flex items-center justify-between">
+                <span>Plate II — Working method</span>
+                <span>Fig. 02</span>
+              </figcaption>
+            </figure>
+
+            <ul class="mt-8 divide-y divide-ink/10 dark:divide-paper-dark/12">
+              <li class="py-3 flex items-center justify-between">
+                <span class="label-mono text-mute dark:text-mute-dark">Discipline</span>
+                <span class="font-mono text-sm">Test-Driven Development</span>
+              </li>
+              <li class="py-3 flex items-center justify-between">
+                <span class="label-mono text-mute dark:text-mute-dark">Workflow</span>
+                <span class="font-mono text-sm">Git Flow / Code Review</span>
+              </li>
+              <li class="py-3 flex items-center justify-between">
+                <span class="label-mono text-mute dark:text-mute-dark">Delivery</span>
+                <span class="font-mono text-sm">Docker / CI/CD</span>
+              </li>
+              <li class="py-3 flex items-center justify-between">
+                <span class="label-mono text-mute dark:text-mute-dark">Strength</span>
+                <span class="font-mono text-sm">Microservices Design</span>
+              </li>
+            </ul>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================================
+         EXPERIENCE — § 02
+    ============================================================ -->
+    <section id="experience" class="py-28 md:py-40 bg-paper border-t border-ink/10 dark:border-paper-dark/15 scroll-mt-24">
+      <div class="container-edit">
+
+        <div class="mb-16 md:mb-24 reveal">
+          <div class="flex items-center justify-between mb-6">
+            <span class="section-num text-coral">§ 02 / Work</span>
+            <span class="section-num text-mute dark:text-mute-dark">P. 03</span>
+          </div>
+          <h2 class="font-display section-headline">
+            Roles, in <span class="font-display-italic">long form.</span>
+          </h2>
+          <p class="kicker mt-6 text-mute dark:text-mute-dark">A selection of recent work — 2020 &rarr; 2026</p>
+        </div>
+
+        <!-- Article-style entries -->
+        <div class="space-y-24 md:space-y-32">
+
+          <!-- Entry 1: Vendidit -->
+          <article class="grid grid-cols-12 gap-6 md:gap-10 reveal">
+            <header class="col-span-12 lg:col-span-4">
+              <div class="label-mono text-mute dark:text-mute-dark mb-4">Article 01 — Present</div>
+              <h3 class="font-display text-5xl md:text-6xl leading-[0.98] tracking-serif-extra-tight">Vendidit Inc.</h3>
+              <p class="label-mono mt-3 text-coral">Senior Software Engineer</p>
+              <p class="font-mono text-sm text-mute dark:text-mute-dark mt-2">May 2024 — Present &middot; Remote</p>
+            </header>
+
+            <div class="col-span-12 lg:col-span-8 lg:pl-10 lg:border-l border-ink/15 dark:border-paper-dark/15">
+              <p class="text-base md:text-[1.05rem] leading-[1.75] text-ink/85 dark:text-paper-dark/85" style="max-width: 65ch;">
+                Designed a robust multi-vendor commerce system from the ground up &mdash; seller onboarding, inventory and customer management woven into a single coherent platform. Wired SendGrid into the spine for real-time buyer-seller email notifications, instrumented the runtime with AWS CloudWatch, and pushed unit-test coverage to <span class="font-medium">53% with Jest</span>.
+              </p>
+              <p class="mt-5 text-base md:text-[1.05rem] leading-[1.75] text-ink/85 dark:text-paper-dark/85" style="max-width: 65ch;">
+                Most of the engineering joy lived in the auction layer: real-time bidding paired with live video streaming, engineered to stay fast and fair as the platform scaled to support <span class="font-medium">thousands of concurrent users</span>. The role is as much cross-functional craft as it is code &mdash; aligning engineering decisions with the commercial reality the business is chasing.
+              </p>
+
+              <div class="mt-7 flex flex-wrap gap-2">
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">Node.js</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">NestJS</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">PostgreSQL</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">AWS</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">Lambda</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">React</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">Next.js</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">TypeScript</span>
+              </div>
+            </div>
+          </article>
+
+          <div class="hairline"></div>
+
+          <!-- Entry 2: Cefalo -->
+          <article class="grid grid-cols-12 gap-6 md:gap-10 reveal">
+            <header class="col-span-12 lg:col-span-4">
+              <div class="label-mono text-mute dark:text-mute-dark mb-4">Article 02</div>
+              <h3 class="font-display text-5xl md:text-6xl leading-[0.98] tracking-serif-extra-tight">Cefalo Bangladesh</h3>
+              <p class="label-mono mt-3 text-coral">Senior Software Engineer</p>
+              <p class="font-mono text-sm text-mute dark:text-mute-dark mt-2">Dec 2021 — Apr 2024 &middot; Hybrid</p>
+            </header>
+
+            <div class="col-span-12 lg:col-span-8 lg:pl-10 lg:border-l border-ink/15 dark:border-paper-dark/15">
+              <p class="text-base md:text-[1.05rem] leading-[1.75] text-ink/85 dark:text-paper-dark/85" style="max-width: 65ch;">
+                Two and a half years inside Norwegian product engineering &mdash; building microservice-based web apps for the rental marketplace <em class="font-display-italic">leid.no</em> with Node.js and Next.js, including a QR-code-driven borrowing flow that turned the physical handoff of tools into a frictionless tap. Architected and maintained a subscription system in PHP / Laravel / Node / Express used across multiple sites including <em class="font-display-italic">friflyt.no</em>, serving a footprint of <span class="font-medium">5M subscribers</span>.
+              </p>
+              <p class="mt-5 text-base md:text-[1.05rem] leading-[1.75] text-ink/85 dark:text-paper-dark/85" style="max-width: 65ch;">
+                On the data side I served Elasticsearch through AWS Lambda and shipped a handful of custom Node modules that stuck. The engineering culture rewarded rigour, which is how the team and I held <span class="font-medium">82.4% unit-test coverage with Jest</span> across services that genuinely needed to stay up.
+              </p>
+
+              <div class="mt-7 flex flex-wrap gap-2">
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">Node.js</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">Express</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">PHP</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">Laravel</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">AWS</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">TypeScript</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">Dato CMS</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">Elasticsearch</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">Lambda</span>
+              </div>
+            </div>
+          </article>
+
+          <div class="hairline"></div>
+
+          <!-- Entry 3: Thrive -->
+          <article class="grid grid-cols-12 gap-6 md:gap-10 reveal">
+            <header class="col-span-12 lg:col-span-4">
+              <div class="label-mono text-mute dark:text-mute-dark mb-4">Article 03</div>
+              <h3 class="font-display text-5xl md:text-6xl leading-[0.98] tracking-serif-extra-tight">Thrive EdTech</h3>
+              <p class="label-mono mt-3 text-coral">Senior Software Engineer</p>
+              <p class="font-mono text-sm text-mute dark:text-mute-dark mt-2">May 2020 — Oct 2021 &middot; Hybrid</p>
+            </header>
+
+            <div class="col-span-12 lg:col-span-8 lg:pl-10 lg:border-l border-ink/15 dark:border-paper-dark/15">
+              <p class="text-base md:text-[1.05rem] leading-[1.75] text-ink/85 dark:text-paper-dark/85" style="max-width: 65ch;">
+                Built microservice web applications for learning analytics &mdash; tools that helped teachers and students see the curve of progress over time, not just the snapshot of a single grade. The platform handled student and teacher results with a quiet honesty about what the numbers actually meant.
+              </p>
+              <p class="mt-5 text-base md:text-[1.05rem] leading-[1.75] text-ink/85 dark:text-paper-dark/85" style="max-width: 65ch;">
+                Designed a school management layer with routine planning and folded in Zoom and Google Meet for virtual classrooms when the world unexpectedly demanded that schools live entirely on the web. A formative role in shipping software to people who had no choice but to depend on it working.
+              </p>
+
+              <div class="mt-7 flex flex-wrap gap-2">
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">PHP</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">Laravel</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">MySQL</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">React</span>
+                <span class="label-mono px-2.5 py-1 border border-ink/20 dark:border-paper-dark/20">AWS</span>
+              </div>
+            </div>
+          </article>
+
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================================
+         PROJECTS — § 03
+    ============================================================ -->
+    <section id="projects" class="py-28 md:py-40 scroll-mt-24">
+      <div class="container-edit">
+        <div class="mb-16 md:mb-24 reveal">
+          <div class="flex items-center justify-between mb-6">
+            <span class="section-num text-coral">§ 03 / Shipping</span>
+            <span class="section-num text-mute dark:text-mute-dark">P. 04</span>
+          </div>
+          <h2 class="font-display section-headline">
+            Projects, <span class="font-display-italic">in print.</span>
+          </h2>
+          <p class="kicker mt-6 text-mute dark:text-mute-dark">Three platforms — auction, rental, editorial. Live, scaled, in production.</p>
+        </div>
+      </div>
+
+      <!-- Featured / Full-bleed: Vendidit -->
+      <article class="reveal">
+        <div class="w-full">
+          <div class="aspect-[16/8] md:aspect-[21/9] overflow-hidden bg-ink/5 dark:bg-paper-dark/10 border-y border-ink/15 dark:border-paper-dark/15">
+            <img src="../../../assets/images/projects/vendidit.png" alt="Vendidit — online auction platform with real-time bidding interface." width="2100" height="900" class="w-full h-full object-cover img-hover" loading="lazy" decoding="async" />
+          </div>
+        </div>
+
+        <div class="container-edit">
+          <div class="grid grid-cols-12 gap-6 md:gap-10 pt-10">
+            <div class="col-span-12 md:col-span-3">
+              <div class="label-mono text-coral">Work / 01 — Featured</div>
+              <div class="font-mono text-sm text-mute dark:text-mute-dark mt-2">vendidit.com</div>
+            </div>
+            <div class="col-span-12 md:col-span-6">
+              <h3 class="font-display text-4xl md:text-5xl leading-[1.02] tracking-serif-extra-tight">Online Auction Platform</h3>
+              <p class="mt-4 text-base md:text-lg leading-[1.7] text-ink/80 dark:text-paper-dark/80" style="max-width: 60ch;">
+                Real-time bidding on items with a smooth, interactive UX. Live video streaming wired through the auction layer for higher engagement and fairness across thousands of concurrent buyers.
+              </p>
+            </div>
+            <div class="col-span-12 md:col-span-3 md:text-right">
+              <div class="label-mono text-mute dark:text-mute-dark mb-2">Stack</div>
+              <p class="font-mono text-sm">NestJS &middot; PostgreSQL &middot; AWS &middot; Lambda</p>
+              <a href="https://vendidit.com" target="_blank" rel="noopener" class="arrow-link mt-6 inline-flex text-coral label-mono ulink">
+                View Project <span class="arrow">&rarr;</span>
+              </a>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <!-- 2-up grid -->
+      <div class="container-edit mt-24 md:mt-32">
+        <div class="grid grid-cols-12 gap-10 md:gap-14">
+
+          <!-- Project 02: friflyt -->
+          <article class="col-span-12 md:col-span-6 reveal">
+            <a href="https://friflyt.no" target="_blank" rel="noopener" class="block group">
+              <div class="aspect-[4/3] overflow-hidden bg-ink/5 dark:bg-paper-dark/10 border border-ink/15 dark:border-paper-dark/20">
+                <img src="../../../assets/images/projects/friflyt.png" alt="friflyt.no — Norwegian outdoor and skiing news platform." width="1200" height="900" class="w-full h-full object-cover img-hover" loading="lazy" decoding="async" />
+              </div>
+            </a>
+            <div class="mt-6 flex items-baseline justify-between">
+              <span class="label-mono text-coral">Work / 02</span>
+              <span class="font-mono text-sm text-mute dark:text-mute-dark">friflyt.no</span>
+            </div>
+            <h3 class="font-display text-3xl md:text-4xl leading-[1.05] mt-2">E-news Platform</h3>
+            <p class="mt-3 text-base leading-[1.7] text-ink/80 dark:text-paper-dark/80" style="max-width: 55ch;">
+              News, reports and field journalism on skiing and outdoor adventure &mdash; centred on Norwegian nature and the rhythms of seasonal life. Editorial CMS over a custom Express backend.
+            </p>
+            <div class="mt-5 flex flex-wrap items-center gap-x-3 gap-y-1">
+              <span class="label-mono text-mute dark:text-mute-dark">Stack:</span>
+              <span class="font-mono text-sm">Express</span>
+              <span class="text-mute">&middot;</span>
+              <span class="font-mono text-sm">MySQL</span>
+              <span class="text-mute">&middot;</span>
+              <span class="font-mono text-sm">AWS</span>
+              <span class="text-mute">&middot;</span>
+              <span class="font-mono text-sm">Lambda</span>
+            </div>
+            <a href="https://friflyt.no" target="_blank" rel="noopener" class="arrow-link mt-6 text-coral label-mono ulink inline-flex">
+              View Project <span class="arrow">&rarr;</span>
+            </a>
+          </article>
+
+          <!-- Project 03: leid -->
+          <article class="col-span-12 md:col-span-6 md:mt-24 reveal">
+            <a href="https://leid.no" target="_blank" rel="noopener" class="block group">
+              <div class="aspect-[4/3] overflow-hidden bg-ink/5 dark:bg-paper-dark/10 border border-ink/15 dark:border-paper-dark/20">
+                <img src="../../../assets/images/projects/leid.png" alt="leid.no — tool rental e-commerce platform with QR-code borrowing flow." width="1200" height="900" class="w-full h-full object-cover img-hover" loading="lazy" decoding="async" />
+              </div>
+            </a>
+            <div class="mt-6 flex items-baseline justify-between">
+              <span class="label-mono text-coral">Work / 03</span>
+              <span class="font-mono text-sm text-mute dark:text-mute-dark">leid.no</span>
+            </div>
+            <h3 class="font-display text-3xl md:text-4xl leading-[1.05] mt-2">E-commerce / Rental</h3>
+            <p class="mt-3 text-base leading-[1.7] text-ink/80 dark:text-paper-dark/80" style="max-width: 55ch;">
+              An e-commerce platform for renting tools instead of buying them &mdash; complete with a QR-code system for fast pickup and return. Built on a microservice spine in Node and Next.js.
+            </p>
+            <div class="mt-5 flex flex-wrap items-center gap-x-3 gap-y-1">
+              <span class="label-mono text-mute dark:text-mute-dark">Stack:</span>
+              <span class="font-mono text-sm">Express</span>
+              <span class="text-mute">&middot;</span>
+              <span class="font-mono text-sm">PostgreSQL</span>
+              <span class="text-mute">&middot;</span>
+              <span class="font-mono text-sm">AWS</span>
+              <span class="text-mute">&middot;</span>
+              <span class="font-mono text-sm">Lambda</span>
+            </div>
+            <a href="https://leid.no" target="_blank" rel="noopener" class="arrow-link mt-6 text-coral label-mono ulink inline-flex">
+              View Project <span class="arrow">&rarr;</span>
+            </a>
+          </article>
+
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================================
+         SKILLS — § 04
+    ============================================================ -->
+    <section id="skills" class="py-28 md:py-40 border-t border-ink/10 dark:border-paper-dark/15 scroll-mt-24">
+      <div class="container-edit">
+
+        <div class="mb-16 md:mb-24 reveal">
+          <div class="flex items-center justify-between mb-6">
+            <span class="section-num text-coral">§ 04 / Stack</span>
+            <span class="section-num text-mute dark:text-mute-dark">P. 05</span>
+          </div>
+          <h2 class="font-display section-headline">
+            The <span class="font-display-italic">working</span> stack.
+          </h2>
+          <p class="kicker mt-6 text-mute dark:text-mute-dark">Tools used in production, listed by category — not by logo.</p>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 md:gap-10 reveal">
+
+          <!-- Backend -->
+          <div>
+            <div class="flex items-baseline justify-between border-b border-ink/20 dark:border-paper-dark/20 pb-3 mb-5">
+              <h3 class="label-mono">Backend</h3>
+              <span class="label-mono text-coral">01</span>
+            </div>
+            <ul class="font-mono text-sm space-y-3">
+              <li class="flex items-center justify-between"><span>NestJS</span><span class="text-mute dark:text-mute-dark">primary</span></li>
+              <li class="flex items-center justify-between"><span>Node.js</span><span class="text-mute dark:text-mute-dark">primary</span></li>
+              <li class="flex items-center justify-between"><span>Laravel</span><span class="text-mute dark:text-mute-dark">strong</span></li>
+              <li class="flex items-center justify-between"><span>PHP</span><span class="text-mute dark:text-mute-dark">strong</span></li>
+              <li class="flex items-center justify-between"><span>Java</span><span class="text-mute dark:text-mute-dark">working</span></li>
+              <li class="flex items-center justify-between"><span>Python</span><span class="text-mute dark:text-mute-dark">working</span></li>
+            </ul>
+          </div>
+
+          <!-- Frontend -->
+          <div>
+            <div class="flex items-baseline justify-between border-b border-ink/20 dark:border-paper-dark/20 pb-3 mb-5">
+              <h3 class="label-mono">Frontend</h3>
+              <span class="label-mono text-coral">02</span>
+            </div>
+            <ul class="font-mono text-sm space-y-3">
+              <li class="flex items-center justify-between"><span>React</span><span class="text-mute dark:text-mute-dark">primary</span></li>
+              <li class="flex items-center justify-between"><span>JavaScript</span><span class="text-mute dark:text-mute-dark">primary</span></li>
+              <li class="flex items-center justify-between"><span>HTML5</span><span class="text-mute dark:text-mute-dark">strong</span></li>
+              <li class="flex items-center justify-between"><span>CSS3</span><span class="text-mute dark:text-mute-dark">strong</span></li>
+            </ul>
+          </div>
+
+          <!-- Infra & Cloud -->
+          <div>
+            <div class="flex items-baseline justify-between border-b border-ink/20 dark:border-paper-dark/20 pb-3 mb-5">
+              <h3 class="label-mono">Infra &amp; Cloud</h3>
+              <span class="label-mono text-coral">03</span>
+            </div>
+            <ul class="font-mono text-sm space-y-3">
+              <li class="flex items-center justify-between"><span>AWS</span><span class="text-mute dark:text-mute-dark">primary</span></li>
+              <li class="flex items-center justify-between"><span>Docker</span><span class="text-mute dark:text-mute-dark">primary</span></li>
+              <li class="flex items-center justify-between"><span>CI/CD</span><span class="text-mute dark:text-mute-dark">strong</span></li>
+              <li class="flex items-center justify-between"><span>PostgreSQL</span><span class="text-mute dark:text-mute-dark">strong</span></li>
+              <li class="flex items-center justify-between"><span>MySQL</span><span class="text-mute dark:text-mute-dark">strong</span></li>
+              <li class="flex items-center justify-between"><span>MongoDB</span><span class="text-mute dark:text-mute-dark">working</span></li>
+            </ul>
+          </div>
+
+          <!-- Testing & Tools -->
+          <div>
+            <div class="flex items-baseline justify-between border-b border-ink/20 dark:border-paper-dark/20 pb-3 mb-5">
+              <h3 class="label-mono">Testing &amp; Tools</h3>
+              <span class="label-mono text-coral">04</span>
+            </div>
+            <ul class="font-mono text-sm space-y-3">
+              <li class="flex items-center justify-between"><span>Jest</span><span class="text-mute dark:text-mute-dark">primary</span></li>
+              <li class="flex items-center justify-between"><span>Git</span><span class="text-mute dark:text-mute-dark">primary</span></li>
+              <li class="flex items-center justify-between"><span>TDD</span><span class="text-mute dark:text-mute-dark">discipline</span></li>
+              <li class="flex items-center justify-between"><span>Git Flow</span><span class="text-mute dark:text-mute-dark">discipline</span></li>
+            </ul>
+          </div>
+
+        </div>
+
+        <!-- Pull-quote -->
+        <div class="mt-24 md:mt-32 reveal">
+          <div class="hairline"></div>
+          <blockquote class="grid grid-cols-12 gap-6 md:gap-10 pt-12">
+            <div class="col-span-12 lg:col-span-2">
+              <span class="label-mono text-coral">Pull Quote</span>
+            </div>
+            <p class="col-span-12 lg:col-span-10 font-display text-3xl md:text-5xl leading-[1.1] tracking-serif-tight" style="max-width: 22ch;">
+              <span class="text-coral">&ldquo;</span>The right architecture isn&rsquo;t the cleverest one &mdash; it&rsquo;s the one a team can <span class="font-display-italic">live with</span> for five years.<span class="text-coral">&rdquo;</span>
+            </p>
+          </blockquote>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================================
+         CONTACT — § 05
+    ============================================================ -->
+    <section id="contact" class="py-28 md:py-40 border-t border-ink/10 dark:border-paper-dark/15 scroll-mt-24">
+      <div class="container-edit">
+
+        <div class="mb-16 md:mb-20 reveal">
+          <div class="flex items-center justify-between mb-6">
+            <span class="section-num text-coral">§ 05 / Contact</span>
+            <span class="section-num text-mute dark:text-mute-dark">P. 06</span>
+          </div>
+          <h2 class="font-display section-headline">
+            Let&rsquo;s build <span class="font-display-italic">something.</span>
+          </h2>
+          <p class="kicker mt-6 text-mute dark:text-mute-dark">Open to senior backend / fullstack roles, contract or full-time.</p>
+        </div>
+
+        <div class="grid grid-cols-12 gap-10 md:gap-14">
+
+          <!-- Left: contact info -->
+          <div class="col-span-12 lg:col-span-5 reveal">
+            <p class="text-lg leading-[1.7] text-ink/85 dark:text-paper-dark/85" style="max-width: 50ch;">
+              Tell me about your team, what you&rsquo;re building, what hurts. I read every message and respond within a couple of business days.
+            </p>
+
+            <dl class="mt-12 space-y-6">
+              <div>
+                <dt class="label-mono text-mute dark:text-mute-dark">Email</dt>
+                <dd class="mt-1.5"><a href="mailto:rafatahmedorik@gmail.com" class="font-display text-2xl md:text-3xl ulink">rafatahmedorik@gmail.com</a></dd>
+              </div>
+              <div>
+                <dt class="label-mono text-mute dark:text-mute-dark">Phone</dt>
+                <dd class="mt-1.5"><a href="tel:+8801911750945" class="font-display text-2xl md:text-3xl ulink">+880 (1911) 750-945</a></dd>
+              </div>
+              <div>
+                <dt class="label-mono text-mute dark:text-mute-dark">Location</dt>
+                <dd class="mt-1.5 font-display text-2xl md:text-3xl">Dhaka, Bangladesh</dd>
+              </div>
+            </dl>
+
+            <div class="mt-12 flex items-center gap-5">
+              <a href="https://github.com/rafat69ahmed" target="_blank" rel="noopener" aria-label="GitHub" class="w-11 h-11 inline-flex items-center justify-center border border-ink/20 dark:border-paper-dark/20 hover:border-coral hover:text-coral transition-colors">
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.6.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.3.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.4-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.3-1.3-5.3-5.7 0-1.3.4-2.3 1.2-3.1-.1-.4-.5-1.6.1-3.2 0 0 1-.3 3.3 1.2 1-.3 2-.4 3-.4s2 .1 3 .4c2.3-1.5 3.3-1.2 3.3-1.2.7 1.6.2 2.8.1 3.2.8.8 1.2 1.9 1.2 3.1 0 4.5-2.7 5.4-5.3 5.7.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>
+              </a>
+              <a href="https://linkedin.com/in/rafat69ahmed/" target="_blank" rel="noopener" aria-label="LinkedIn" class="w-11 h-11 inline-flex items-center justify-center border border-ink/20 dark:border-paper-dark/20 hover:border-coral hover:text-coral transition-colors">
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.45 20.45h-3.55v-5.6c0-1.34-.03-3.06-1.87-3.06-1.87 0-2.16 1.46-2.16 2.97v5.69H9.32V9h3.41v1.56h.05c.48-.9 1.64-1.87 3.37-1.87 3.6 0 4.27 2.37 4.27 5.45v6.31zM5.34 7.43a2.06 2.06 0 1 1 0-4.12 2.06 2.06 0 0 1 0 4.12zM7.12 20.45H3.56V9h3.56v11.45z"/></svg>
+              </a>
+              <a href="https://facebook.com/rafat.ahmed.146" target="_blank" rel="noopener" aria-label="Facebook" class="w-11 h-11 inline-flex items-center justify-center border border-ink/20 dark:border-paper-dark/20 hover:border-coral hover:text-coral transition-colors">
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M22 12a10 10 0 1 0-11.56 9.88v-7H8v-2.88h2.44V9.79c0-2.42 1.44-3.76 3.65-3.76 1.06 0 2.16.19 2.16.19v2.38h-1.22c-1.2 0-1.57.74-1.57 1.51v1.81h2.68l-.43 2.88h-2.25v7A10 10 0 0 0 22 12z"/></svg>
+              </a>
+            </div>
+          </div>
+
+          <!-- Right: form -->
+          <div class="col-span-12 lg:col-span-7 reveal">
+            <form id="contact-form" novalidate class="space-y-2">
+              <!-- name -->
+              <div>
+                <label for="cf-name" class="label-mono block mb-1 text-mute dark:text-mute-dark">Name <span class="text-coral" aria-hidden="true">*</span></label>
+                <input id="cf-name" name="name" type="text" required autocomplete="name" class="field-input" aria-required="true" aria-describedby="cf-name-err" />
+                <p id="cf-name-err" class="hidden mt-2 label-mono text-coral" role="alert">Please enter your name.</p>
+              </div>
+
+              <!-- email -->
+              <div class="pt-6">
+                <label for="cf-email" class="label-mono block mb-1 text-mute dark:text-mute-dark">Email <span class="text-coral" aria-hidden="true">*</span></label>
+                <input id="cf-email" name="email" type="email" required autocomplete="email" inputmode="email" class="field-input" aria-required="true" aria-describedby="cf-email-err" />
+                <p id="cf-email-err" class="hidden mt-2 label-mono text-coral" role="alert">Please enter a valid email address.</p>
+              </div>
+
+              <!-- subject -->
+              <div class="pt-6">
+                <label for="cf-subject" class="label-mono block mb-1 text-mute dark:text-mute-dark">Subject</label>
+                <input id="cf-subject" name="subject" type="text" class="field-input" />
+              </div>
+
+              <!-- message -->
+              <div class="pt-6">
+                <label for="cf-message" class="label-mono block mb-1 text-mute dark:text-mute-dark">Message <span class="text-coral" aria-hidden="true">*</span></label>
+                <textarea id="cf-message" name="message" rows="5" required class="field-input resize-y" aria-required="true" aria-describedby="cf-message-err"></textarea>
+                <p id="cf-message-err" class="hidden mt-2 label-mono text-coral" role="alert">Please write a short message (10+ characters).</p>
+              </div>
+
+              <!-- submit -->
+              <div class="pt-10 flex flex-wrap items-center gap-5">
+                <button type="submit" class="arrow-link inline-flex items-center gap-3 label-mono bg-ink text-paper dark:bg-paper-dark dark:text-ink-dark h-12 px-7 hover:bg-coral hover:text-paper transition-colors">
+                  <span id="cf-submit-text">Send Message</span>
+                  <span class="arrow">&rarr;</span>
+                </button>
+                <p class="label-mono text-mute dark:text-mute-dark">Replies within 1&ndash;2 business days.</p>
+              </div>
+
+              <!-- success -->
+              <div id="cf-success" class="hidden mt-8 p-5 border border-coral/40 bg-coral/5 text-ink dark:text-paper-dark" role="status" aria-live="polite">
+                <p class="font-display text-2xl text-coral">Thank you.</p>
+                <p class="mt-1 text-base">Your message is in. I&rsquo;ll be in touch shortly.</p>
+              </div>
+            </form>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- ============================================================
+       FOOTER
+  ============================================================ -->
+  <footer class="bg-ink text-paper dark:bg-ink-dark dark:text-paper-dark border-t border-paper/20 dark:border-paper-dark/15">
+
+    <!-- Big sign-off -->
+    <div class="container-edit pt-20 md:pt-28 pb-10 md:pb-16">
+      <div class="flex items-center justify-between mb-10">
+        <span class="section-num text-coral">§ Colophon</span>
+        <span class="section-num text-paper/55 dark:text-paper-dark/60">End / 2026</span>
+      </div>
+      <h2 class="font-display signoff">
+        Thanks for <span class="font-display-italic text-coral">visiting.</span>
+      </h2>
+    </div>
+
+    <!-- Hairline -->
+    <div class="container-edit"><div class="hairline" style="background: rgba(245, 242, 236, 0.2);"></div></div>
+
+    <!-- Bottom strip -->
+    <div class="container-edit py-10 md:py-12 grid grid-cols-12 gap-6">
+      <div class="col-span-12 md:col-span-4">
+        <p class="label-mono text-paper/60 dark:text-paper-dark/60">Editorial Folio &mdash; Option C</p>
+        <p class="mt-3 font-display text-2xl">Rafat Ahmed</p>
+      </div>
+      <nav class="col-span-12 md:col-span-4 flex flex-col gap-2" aria-label="Footer">
+        <a href="#about" class="label-mono ulink">01 About</a>
+        <a href="#experience" class="label-mono ulink">02 Work</a>
+        <a href="#projects" class="label-mono ulink">03 Shipping</a>
+        <a href="#skills" class="label-mono ulink">04 Stack</a>
+        <a href="#contact" class="label-mono ulink">05 Contact</a>
+      </nav>
+      <div class="col-span-12 md:col-span-4 flex flex-col gap-2 md:items-end">
+        <p class="label-mono"><a href="mailto:rafatahmedorik@gmail.com" class="ulink">rafatahmedorik@gmail.com</a></p>
+        <p class="label-mono"><a href="tel:+8801911750945" class="ulink">+880 (1911) 750-945</a></p>
+        <p class="label-mono text-paper/55 dark:text-paper-dark/60 mt-2">
+          &copy; <span id="footer-year">2026</span> Rafat Ahmed. Set in Instrument Serif, Inter Tight &amp; JetBrains Mono.
+        </p>
+      </div>
+    </div>
+  </footer>
+
+  <!-- Scroll-to-top -->
+  <button id="to-top" type="button" aria-label="Scroll to top" class="to-top fixed bottom-6 right-6 md:bottom-8 md:right-8 z-30 w-12 h-12 inline-flex items-center justify-center bg-coral text-paper rounded-full shadow-lg">
+    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg>
+  </button>
+
+  <!-- ============================================================
+       SCRIPTS
+  ============================================================ -->
+  <script>
+    (function () {
+      // ---------- Theme toggle (with localStorage) ----------
+      const root = document.documentElement;
+      const themeKey = 'option-c-theme';
+      const stored = localStorage.getItem(themeKey);
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if (stored === 'dark' || (!stored && prefersDark)) root.classList.add('dark');
+
+      const toggleBtn = document.getElementById('theme-toggle');
+      toggleBtn?.addEventListener('click', () => {
+        root.classList.toggle('dark');
+        localStorage.setItem(themeKey, root.classList.contains('dark') ? 'dark' : 'light');
+      });
+
+      // ---------- Mobile menu ----------
+      const menu = document.getElementById('mobile-menu');
+      const openBtn = document.getElementById('menu-open');
+      const closeBtn = document.getElementById('menu-close');
+      const setMenu = (open) => {
+        menu.classList.toggle('open', open);
+        openBtn?.setAttribute('aria-expanded', String(open));
+        document.body.style.overflow = open ? 'hidden' : '';
+      };
+      openBtn?.addEventListener('click', () => setMenu(true));
+      closeBtn?.addEventListener('click', () => setMenu(false));
+      document.querySelectorAll('.mobile-link').forEach((a) => a.addEventListener('click', () => setMenu(false)));
+      document.addEventListener('keydown', (e) => { if (e.key === 'Escape') setMenu(false); });
+
+      // ---------- Reveal on scroll ----------
+      const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      const reveals = document.querySelectorAll('.reveal');
+      if (reduceMotion || !('IntersectionObserver' in window)) {
+        reveals.forEach((el) => el.classList.add('visible'));
+      } else {
+        const io = new IntersectionObserver((entries) => {
+          entries.forEach((e) => {
+            if (e.isIntersecting) {
+              e.target.classList.add('visible');
+              io.unobserve(e.target);
+            }
+          });
+        }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' });
+        reveals.forEach((el) => io.observe(el));
+      }
+
+      // ---------- Scroll-to-top ----------
+      const toTop = document.getElementById('to-top');
+      const onScroll = () => {
+        const show = window.scrollY > 400;
+        toTop.classList.toggle('visible', show);
+      };
+      window.addEventListener('scroll', onScroll, { passive: true });
+      toTop?.addEventListener('click', () => window.scrollTo({ top: 0, behavior: reduceMotion ? 'auto' : 'smooth' }));
+
+      // ---------- Footer year ----------
+      document.getElementById('footer-year').textContent = new Date().getFullYear();
+
+      // ---------- Contact form validation ----------
+      const form = document.getElementById('contact-form');
+      const nameI = document.getElementById('cf-name');
+      const emailI = document.getElementById('cf-email');
+      const msgI = document.getElementById('cf-message');
+      const success = document.getElementById('cf-success');
+      const submitText = document.getElementById('cf-submit-text');
+
+      const showErr = (id, show) => {
+        document.getElementById(id).classList.toggle('hidden', !show);
+      };
+      const validEmail = (v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v.trim());
+
+      nameI.addEventListener('blur', () => showErr('cf-name-err', !nameI.value.trim()));
+      emailI.addEventListener('blur', () => showErr('cf-email-err', !validEmail(emailI.value)));
+      msgI.addEventListener('blur', () => showErr('cf-message-err', msgI.value.trim().length < 10));
+
+      form?.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const errors = {
+          name: !nameI.value.trim(),
+          email: !validEmail(emailI.value),
+          message: msgI.value.trim().length < 10
+        };
+        showErr('cf-name-err', errors.name);
+        showErr('cf-email-err', errors.email);
+        showErr('cf-message-err', errors.message);
+
+        const firstErrorField = errors.name ? nameI : errors.email ? emailI : errors.message ? msgI : null;
+        if (firstErrorField) {
+          firstErrorField.focus();
+          return;
+        }
+
+        submitText.textContent = 'Sending';
+        setTimeout(() => {
+          form.reset();
+          submitText.textContent = 'Send Message';
+          success.classList.remove('hidden');
+          success.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'center' });
+          setTimeout(() => success.classList.add('hidden'), 6000);
+        }, 600);
+      });
+
+      // ---------- Header shadow on scroll ----------
+      const header = document.getElementById('site-header');
+      const headerScroll = () => {
+        if (window.scrollY > 8) {
+          header.classList.add('shadow-[0_1px_0_rgba(15,15,15,0.06)]');
+        } else {
+          header.classList.remove('shadow-[0_1px_0_rgba(15,15,15,0.06)]');
+        }
+      };
+      window.addEventListener('scroll', headerScroll, { passive: true });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
- New design: mint/cream/teal palette, Caveat script section accents, inline-SVG landscape hero, wavy section dividers, dashed timeline. Full dark mode (deep forest variant) + a11y pass (4.5:1 contrast, 44px touch targets, focus rings, prefers-reduced-motion).
- Experience updated: TechJays Lead SWE (Jul 2025 – Present) added at top; Vendidit becomes "Green Pants Studio (Vendidit as client), Mar 2024 – Jul 2025"; Cefalo end date corrected to Feb 2024.
- Hero subtitle, page title and meta now say "Lead Software Engineer".
- Contact section widened so email/phone no longer wrap; added open-to- opportunities pulse pill; social icons converted to labeled pills.
- Footer refreshed: small landscape SVG, quick anchor links, labeled social pills, fine-print row with rafatahmed.xyz and back-to-top.
- Keep option-b.html (engineer-spirit) and option-c.html (bold editorial) as alternative design explorations for later.